### PR TITLE
Support Clang and libTooling built with C++03 ABI

### DIFF
--- a/clpy_setup_build.py
+++ b/clpy_setup_build.py
@@ -16,14 +16,21 @@ from install import utils
 import subprocess
 
 print("building ultima")
+
+is_clang_built_with_cxx11_abi = subprocess.Popen(
+    'nm `which clang++` | grep __cxx11 > /dev/null',
+    shell=True).wait() == 0
+
 if subprocess.Popen(
-        'clang++ -std=c++11 -Wall -Wextra -O3 -pedantic-errors ultima.cpp '
-        '-lclangTooling -lclangFrontendTool -lclangFrontend -lclangDriver '
-        '-lclangSerialization -lclangCodeGen -lclangParse -lclangSema '
-        '-lclangStaticAnalyzerFrontend -lclangStaticAnalyzerCheckers '
-        '-lclangStaticAnalyzerCore -lclangAnalysis -lclangARCMigrate '
-        '-lclangRewrite -lclangEdit -lclangAST -lclangLex -lclangBasic '
-        '-lclang `llvm-config --libs --system-libs` -fno-rtti -o ultima',
+        'clang++ -std=c++11 -D_GLIBCXX_USE_CXX11_ABI={} -Wall -Wextra '
+        '-O3 -pedantic-errors ultima.cpp -lclangTooling -lclangFrontendTool '
+        '-lclangFrontend -lclangDriver -lclangSerialization -lclangCodeGen '
+        '-lclangParse -lclangSema -lclangStaticAnalyzerFrontend '
+        '-lclangStaticAnalyzerCheckers -lclangStaticAnalyzerCore '
+        '-lclangAnalysis -lclangARCMigrate -lclangRewrite -lclangEdit '
+        '-lclangAST -lclangLex -lclangBasic -lclang '
+        '`llvm-config --libs --system-libs` -fno-rtti -o ultima'
+        .format(1 if is_clang_built_with_cxx11_abi else 0),
         cwd=os.path.dirname(__file__)+"/ultima",
         shell=True).wait() != 0:
     raise RuntimeError('Build ultima is failed.')


### PR DESCRIPTION
Building of ultima using clang built with C++03 ABI is failed, because `clang++` uses C++11 ABI at default then ABIs between object file of ultima and libTooling will be conflicted. (reported by @telmin in #42)

In this PR, we check an ABI of `clang++` , then build ultima with the `clang++`'s ABI.