### PR TITLE
Fix raw CArray access with an index

### DIFF
--- a/jenkins/build_and_test.sh
+++ b/jenkins/build_and_test.sh
@@ -43,6 +43,7 @@ tests/clpy_tests/binary_tests/
 "
 
 TEST_FILES="
+tests/clpy_tests/core_tests/test_carray.py
 tests/clpy_tests/core_tests/test_core.py
 tests/clpy_tests/core_tests/test_elementwise.py
 tests/clpy_tests/core_tests/test_flags.py

--- a/tests/clpy_tests/core_tests/test_carray.py
+++ b/tests/clpy_tests/core_tests/test_carray.py
@@ -1,32 +1,42 @@
 import unittest
 
 import clpy
+from clpy.backend.opencl.exceptions import OpenCLProgramBuildError
 from clpy import testing
+
+import six
 
 
 class TestCArray(unittest.TestCase):
 
-    def test_size(self):
-        x = clpy.arange(3).astype('i')
-        y = clpy.ElementwiseKernel(
-            'raw int32 x', 'int32 y', 'y = x.size()', 'test_carray_size',
-        )(x, size=1)
-        self.assertEqual(int(y[0]), 3)
+    def test_size(self):  # TODO(vorj): support CArray::size()
+        with six.assertRaisesRegex(self, OpenCLProgramBuildError,
+                                   "not a structure or union"):
+            x = clpy.arange(3).astype('i')
+            y = clpy.ElementwiseKernel(
+                'raw int32 x', 'int32 y', 'y = x.size()', 'test_carray_size',
+            )(x, size=1)
+            self.assertEqual(int(y[0]), 3)
 
-    def test_shape(self):
-        x = clpy.arange(6).reshape((2, 3)).astype('i')
-        y = clpy.ElementwiseKernel(
-            'raw int32 x', 'int32 y', 'y = x.shape()[i]', 'test_carray_shape',
-        )(x, size=2)
-        testing.assert_array_equal(y, (2, 3))
+    def test_shape(self):  # TODO(vorj): support CArray::shape()
+        with six.assertRaisesRegex(self, OpenCLProgramBuildError,
+                                   "not a structure or union"):
+            x = clpy.arange(6).reshape((2, 3)).astype('i')
+            y = clpy.ElementwiseKernel(
+                'raw int32 x', 'int32 y', 'y = x.shape()[i]',
+                'test_carray_shape',
+            )(x, size=2)
+            testing.assert_array_equal(y, (2, 3))
 
-    def test_strides(self):
-        x = clpy.arange(6).reshape((2, 3)).astype('i')
-        y = clpy.ElementwiseKernel(
-            'raw int32 x', 'int32 y', 'y = x.strides()[i]',
-            'test_carray_strides',
-        )(x, size=2)
-        testing.assert_array_equal(y, (12, 4))
+    def test_strides(self):  # TODO(vorj): support CArray::strides()
+        with six.assertRaisesRegex(self, OpenCLProgramBuildError,
+                                   "not a structure or union"):
+            x = clpy.arange(6).reshape((2, 3)).astype('i')
+            y = clpy.ElementwiseKernel(
+                'raw int32 x', 'int32 y', 'y = x.strides()[i]',
+                'test_carray_strides',
+            )(x, size=2)
+            testing.assert_array_equal(y, (12, 4))
 
     def test_getitem_int(self):
         x = clpy.arange(24).reshape((2, 3, 4)).astype('i')

--- a/ultima/ultima.cpp
+++ b/ultima/ultima.cpp
@@ -1109,14 +1109,18 @@ public:
         });
         if(var_info == func_arg_info.back().end())
           throw std::runtime_error("only 'raw' CArray can subscript");
-        os << name << "[get_CArrayIndexRaw_" << var_info->ndim;
+        os << name << "[get_CArrayIndex";
         if(var_info->ndim > 1){
           const auto type = Node->getArg(1)->getType();
           if(auto array = type->getAsArrayTypeUnsafe())
-            os << '_' << to_identifier(array->getElementType()->getUnqualifiedDesugaredType()->getLocallyUnqualifiedSingleStepDesugaredType().getAsString());
+            os << "Raw_" << var_info->ndim << '_' << to_identifier(array->getElementType()->getUnqualifiedDesugaredType()->getLocallyUnqualifiedSingleStepDesugaredType().getAsString());
           else if(auto pointer = type->getAs<clang::PointerType>())
-            os << '_' << to_identifier(pointer->getPointeeType()->getUnqualifiedDesugaredType()->getLocallyUnqualifiedSingleStepDesugaredType().getAsString());
+            os << "Raw_" << var_info->ndim << '_' << to_identifier(pointer->getPointeeType()->getUnqualifiedDesugaredType()->getLocallyUnqualifiedSingleStepDesugaredType().getAsString());
+          else
+            os << "I_" << var_info->ndim;
         }
+        else
+          os << "Raw_" << var_info->ndim;
         os << "(&" << name << "_info, ";
         PrintExpr(Node->getArg(1));
         os << ")]";


### PR DESCRIPTION
Current Ultima can't handle raw CArray access with **an index** (like below) correctly:

```cpp
CArray<float, 2> arr;
arr[0]; //Current Ultima can't handle this.
int indices[2] = {0, 1};
arr[indices]; //This is OK.
```

This PR fix the problem.