### PR TITLE
Fix ultima gets assertion failed

### DIFF
--- a/ultima/ultima.cpp
+++ b/ultima/ultima.cpp
@@ -1803,12 +1803,25 @@ public:
     return os;
   }
 
+  static const clang::AttrVec& get_attrs(const clang::Decl* d){
+    if(d->hasAttrs())
+      return d->getAttrs();
+    else{
+      static clang::AttrVec dummy(0);
+      return dummy;
+    }
+  }
+
+  static llvm::ArrayRef<const clang::Attr*> get_attrs(const clang::AttributedStmt* s){
+    return s->getAttrs();
+  }
+
   template<typename T>
   void prettyPrintAttributes(T* D){
     if (policy.PolishForDeclaration)
       return;
 
-    for (auto *x : D->getAttrs()) {
+    for (auto *x : get_attrs(D)) {
       if (x->isInherited() || x->isImplicit())
         continue;
       if(auto aa = clang::dyn_cast<clang::AnnotateAttr>(x))
@@ -1832,7 +1845,7 @@ public:
     if (policy.PolishForDeclaration)
       return annons;
 
-    for (auto* x : D->getAttrs()) {
+    for (auto* x : get_attrs(D)) {
       if(auto aa = clang::dyn_cast<clang::AnnotateAttr>(x)){
         auto an = aa->getAnnotation();
         if(an == "cl_global")


### PR DESCRIPTION
Close #48 

Current ultima doesn't check that a declaration has attributes or not.
It seems that the check doesn't be needed with Release-built Clang, but it makes assertion failed with assertion-enabled Clang.

The ultima in this PR checks that.