### PR TITLE
Support CArray::shape()

### DIFF
--- a/tests/clpy_tests/core_tests/test_carray.py
+++ b/tests/clpy_tests/core_tests/test_carray.py
@@ -19,16 +19,12 @@ class TestCArray(unittest.TestCase):
             )(x, size=1)
             self.assertEqual(int(y[0]), 3)
 
-    def test_shape(self):  # TODO(vorj): support CArray::shape()
-        with six.assertRaisesRegex(self, UltimaRuntimeError,
-                                   "Current ultima doesn't support "
-                                   "CArray::shape()"):
-            x = clpy.arange(6).reshape((2, 3)).astype('i')
-            y = clpy.ElementwiseKernel(
-                'raw int32 x', 'int32 y', 'y = x.shape()[i]',
-                'test_carray_shape',
-            )(x, size=2)
-            testing.assert_array_equal(y, (2, 3))
+    def test_shape(self):
+        x = clpy.arange(6).reshape((2, 3)).astype('i')
+        y = clpy.ElementwiseKernel(
+            'raw int32 x', 'int32 y', 'y = x.shape()[i]', 'test_carray_shape',
+        )(x, size=2)
+        testing.assert_array_equal(y, (2, 3))
 
     def test_strides(self):  # TODO(vorj): support CArray::strides()
         with six.assertRaisesRegex(self, UltimaRuntimeError,

--- a/tests/clpy_tests/core_tests/test_carray.py
+++ b/tests/clpy_tests/core_tests/test_carray.py
@@ -1,7 +1,7 @@
 import unittest
 
 import clpy
-from clpy.backend.opencl.exceptions import OpenCLProgramBuildError
+from clpy.backend.ultima.exceptions import UltimaRuntimeError
 from clpy import testing
 
 import six
@@ -10,8 +10,9 @@ import six
 class TestCArray(unittest.TestCase):
 
     def test_size(self):  # TODO(vorj): support CArray::size()
-        with six.assertRaisesRegex(self, OpenCLProgramBuildError,
-                                   "not a structure or union"):
+        with six.assertRaisesRegex(self, UltimaRuntimeError,
+                                   "Current ultima doesn't support "
+                                   "CArray::size()"):
             x = clpy.arange(3).astype('i')
             y = clpy.ElementwiseKernel(
                 'raw int32 x', 'int32 y', 'y = x.size()', 'test_carray_size',
@@ -19,8 +20,9 @@ class TestCArray(unittest.TestCase):
             self.assertEqual(int(y[0]), 3)
 
     def test_shape(self):  # TODO(vorj): support CArray::shape()
-        with six.assertRaisesRegex(self, OpenCLProgramBuildError,
-                                   "not a structure or union"):
+        with six.assertRaisesRegex(self, UltimaRuntimeError,
+                                   "Current ultima doesn't support "
+                                   "CArray::shape()"):
             x = clpy.arange(6).reshape((2, 3)).astype('i')
             y = clpy.ElementwiseKernel(
                 'raw int32 x', 'int32 y', 'y = x.shape()[i]',
@@ -29,8 +31,9 @@ class TestCArray(unittest.TestCase):
             testing.assert_array_equal(y, (2, 3))
 
     def test_strides(self):  # TODO(vorj): support CArray::strides()
-        with six.assertRaisesRegex(self, OpenCLProgramBuildError,
-                                   "not a structure or union"):
+        with six.assertRaisesRegex(self, UltimaRuntimeError,
+                                   "Current ultima doesn't support "
+                                   "CArray::strides()"):
             x = clpy.arange(6).reshape((2, 3)).astype('i')
             y = clpy.ElementwiseKernel(
                 'raw int32 x', 'int32 y', 'y = x.strides()[i]',

--- a/ultima/ultima.cpp
+++ b/ultima/ultima.cpp
@@ -1158,21 +1158,21 @@ public:
       if(base_type->getDecl()->getName() == "CIndexer"
       && member_expr->getMemberNameInfo().getAsString() == "size"){
         auto ind = dig_expr(base);
-        if(clang::dyn_cast<clang::DeclRefExpr>(ind) == nullptr)
+        if(!clang::isa<clang::DeclRefExpr>(ind))
           throw std::runtime_error("Current ultima only support calling CIndexer::size() with a CIndexer object.");
         Visit(ind);
         os << "_size";
         return;
       }
       else if(base_type->getDecl()->getName() == "CArray"){
-        auto ind = dig_expr(base);
+        auto raw = clang::dyn_cast<clang::DeclRefExpr>(dig_expr(base));
         if(member_expr->getMemberNameInfo().getAsString() == "size")
           throw std::runtime_error("Current ultima doesn't support CArray::size().");
         else if(member_expr->getMemberNameInfo().getAsString() == "shape"){
-          if(clang::dyn_cast<clang::DeclRefExpr>(ind) == nullptr)
+          if(raw == nullptr)
             throw std::runtime_error("Current ultima only support calling CArray::shape() with a CArray object.");
           os << "(const size_t*)(";
-          Visit(ind);
+          Visit(raw);
           os << "_info.shape_)";
           return;
         }

--- a/ultima/ultima.cpp
+++ b/ultima/ultima.cpp
@@ -1171,9 +1171,21 @@ public:
         else if(member_expr->getMemberNameInfo().getAsString() == "shape"){
           if(raw == nullptr)
             throw std::runtime_error("Current ultima only support calling CArray::shape() with a CArray object.");
-          os << "(const size_t*)(";
-          Visit(raw);
-          os << "_info.shape_)";
+          const auto name = raw->getNameInfo().getAsString();
+          auto var_info = std::find_if(func_arg_info.back().begin(), func_arg_info.back().end(), [name](const function_special_argument_info& t){
+            return t.name == name && t.arg_flag == function_special_argument_info::raw;
+          });
+          if(var_info == func_arg_info.back().end())
+            throw std::runtime_error("only 'raw' CArray can be used to call member function");
+          os << "((const size_t*)";
+          if(var_info->ndim == 0)
+            os << "NULL)";
+          else{
+            if(var_info->ndim == 1)
+              os << '&';
+            Visit(raw);
+            os << "_info.shape_)";
+          }
           return;
         }
         else if(member_expr->getMemberNameInfo().getAsString() == "strides")

--- a/ultima/ultima.cpp
+++ b/ultima/ultima.cpp
@@ -1165,10 +1165,17 @@ public:
         return;
       }
       else if(base_type->getDecl()->getName() == "CArray"){
+        auto ind = dig_expr(base);
         if(member_expr->getMemberNameInfo().getAsString() == "size")
           throw std::runtime_error("Current ultima doesn't support CArray::size().");
-        else if(member_expr->getMemberNameInfo().getAsString() == "shape")
-          throw std::runtime_error("Current ultima doesn't support CArray::shape().");
+        else if(member_expr->getMemberNameInfo().getAsString() == "shape"){
+          if(clang::dyn_cast<clang::DeclRefExpr>(ind) == nullptr)
+            throw std::runtime_error("Current ultima only support calling CArray::shape() with a CArray object.");
+          os << "(const size_t*)(";
+          Visit(ind);
+          os << "_info.shape_)";
+          return;
+        }
         else if(member_expr->getMemberNameInfo().getAsString() == "strides")
           throw std::runtime_error("Current ultima doesn't support CArray::strides().");
       }

--- a/ultima/ultima.cpp
+++ b/ultima/ultima.cpp
@@ -1153,16 +1153,25 @@ public:
   void VisitCXXMemberCallExpr(clang::CXXMemberCallExpr *Node) {
     auto member_expr = clang::dyn_cast<clang::MemberExpr>(Node->getCallee());
     auto base = member_expr->getBase();
-    auto CIndexer = base->getType()->getUnqualifiedDesugaredType()->getAs<clang::RecordType>();
-    if(CIndexer
-    && CIndexer->getDecl()->getName() == "CIndexer"
-    && member_expr->getMemberNameInfo().getAsString() == "size"){
-      auto ind = dig_expr(base);
-      if(clang::dyn_cast<clang::DeclRefExpr>(ind) == nullptr)
-        throw std::runtime_error("Current ultima only support calling CIndexer::size() with a CIndexer object.");
-      Visit(ind);
-      os << "_size";
-      return;
+    auto base_type = base->getType()->getUnqualifiedDesugaredType()->getAs<clang::RecordType>();
+    if(base_type){
+      if(base_type->getDecl()->getName() == "CIndexer"
+      && member_expr->getMemberNameInfo().getAsString() == "size"){
+        auto ind = dig_expr(base);
+        if(clang::dyn_cast<clang::DeclRefExpr>(ind) == nullptr)
+          throw std::runtime_error("Current ultima only support calling CIndexer::size() with a CIndexer object.");
+        Visit(ind);
+        os << "_size";
+        return;
+      }
+      else if(base_type->getDecl()->getName() == "CArray"){
+        if(member_expr->getMemberNameInfo().getAsString() == "size")
+          throw std::runtime_error("Current ultima doesn't support CArray::size().");
+        else if(member_expr->getMemberNameInfo().getAsString() == "shape")
+          throw std::runtime_error("Current ultima doesn't support CArray::shape().");
+        else if(member_expr->getMemberNameInfo().getAsString() == "strides")
+          throw std::runtime_error("Current ultima doesn't support CArray::strides().");
+      }
     }
     // If we have a conversion operator call only print the argument.
     auto *MD = Node->getMethodDecl();


### PR DESCRIPTION
Task of #51 .

This PR contains below changes:
- Current ClPy raise `OpenCLProgramBuildError` when calling CArray member functions.
  ClPy in this PR catch the calling with ultima and raise `UltimaRuntimeError` .
- Support calling `CArray::shape()` .