### PR TITLE
Support CArray member functions

### DIFF
--- a/clpy/backend/function.pyx
+++ b/clpy/backend/function.pyx
@@ -68,9 +68,8 @@ cdef void _launch(clpy.backend.opencl.types.cl_kernel kernel, global_work_size,
                                      " but item size is {2}"
                                      .format(d, a.strides[d], a.itemsize))
                 arrayInfo.shape_and_index[d] = a.shape[d]
-                arrayInfo.shape_and_index[d + ndim] = a.strides[d] \
-                    // a.itemsize
-            arrayInfo.offset = a.data.cl_mem_offset() // a.itemsize
+                arrayInfo.shape_and_index[d + ndim] = a.strides[d]
+            arrayInfo.offset = a.data.cl_mem_offset()
             clpy.backend.opencl.api.SetKernelArg(
                 kernel, i, cython.sizeof(Py_ssize_t)*(2*ndim+1),
                 <void*>&arrayInfo)

--- a/clpy/backend/function.pyx
+++ b/clpy/backend/function.pyx
@@ -30,6 +30,7 @@ cdef struct _CIndexer:
 
 cdef struct _CArray:
     Py_ssize_t offset
+    Py_ssize_t size
     Py_ssize_t shape_and_index[MAX_NDIM * 2]
 
 cdef struct _CArray0:
@@ -70,8 +71,9 @@ cdef void _launch(clpy.backend.opencl.types.cl_kernel kernel, global_work_size,
                 arrayInfo.shape_and_index[d] = a.shape[d]
                 arrayInfo.shape_and_index[d + ndim] = a.strides[d]
             arrayInfo.offset = a.data.cl_mem_offset()
+            arrayInfo.size = a.size
             clpy.backend.opencl.api.SetKernelArg(
-                kernel, i, cython.sizeof(Py_ssize_t)*(2*ndim+1),
+                kernel, i, cython.sizeof(Py_ssize_t)*(1+1+2*ndim),
                 <void*>&arrayInfo)
         elif isinstance(a, clpy.core.core.LocalMem):
             clpy.backend.opencl.utility.SetKernelArgLocalMemory(kernel, i,

--- a/clpy/core/include/clpy/carray.clh
+++ b/clpy/core/include/clpy/carray.clh
@@ -344,6 +344,7 @@ CREATE_CINDXER(15)
 #define CREATE_CARRAY(_NDIM) \
 typedef struct { \
   size_t offset; \
+  size_t size_; \
   size_t shape_[_NDIM]; \
   size_t strides_[_NDIM]; \
 } CArray_##_NDIM; \
@@ -360,6 +361,7 @@ size_t get_CArrayIndexI_##_NDIM(const CArray_##_NDIM* const __restrict__ info, c
 
 typedef struct {
   size_t offset;
+  size_t size_;
 } CArray_0;
 static size_t get_CArrayIndexRaw_0(const CArray_0* const __restrict__ info, const ptrdiff_t idx) {
   return info->offset;
@@ -373,6 +375,7 @@ static size_t get_CArrayIndexI_0(const CArray_0* const __restrict__ info, const 
 
 typedef struct {
   size_t offset;
+  size_t size_;
   size_t shape_;
   size_t strides_;
 } CArray_1;

--- a/tests/clpy_tests/core_tests/test_carray.py
+++ b/tests/clpy_tests/core_tests/test_carray.py
@@ -1,23 +1,17 @@
 import unittest
 
 import clpy
-from clpy.backend.ultima.exceptions import UltimaRuntimeError
 from clpy import testing
-
-import six
 
 
 class TestCArray(unittest.TestCase):
 
-    def test_size(self):  # TODO(vorj): support CArray::size()
-        with six.assertRaisesRegex(self, UltimaRuntimeError,
-                                   "Current ultima doesn't support "
-                                   "CArray::size()"):
-            x = clpy.arange(3).astype('i')
-            y = clpy.ElementwiseKernel(
-                'raw int32 x', 'int32 y', 'y = x.size()', 'test_carray_size',
-            )(x, size=1)
-            self.assertEqual(int(y[0]), 3)
+    def test_size(self):
+        x = clpy.arange(3).astype('i')
+        y = clpy.ElementwiseKernel(
+            'raw int32 x', 'int32 y', 'y = x.size()', 'test_carray_size',
+        )(x, size=1)
+        self.assertEqual(int(y[0]), 3)
 
     def test_shape(self):
         x = clpy.arange(6).reshape((2, 3)).astype('i')

--- a/tests/clpy_tests/core_tests/test_carray.py
+++ b/tests/clpy_tests/core_tests/test_carray.py
@@ -26,16 +26,13 @@ class TestCArray(unittest.TestCase):
         )(x, size=2)
         testing.assert_array_equal(y, (2, 3))
 
-    def test_strides(self):  # TODO(vorj): support CArray::strides()
-        with six.assertRaisesRegex(self, UltimaRuntimeError,
-                                   "Current ultima doesn't support "
-                                   "CArray::strides()"):
-            x = clpy.arange(6).reshape((2, 3)).astype('i')
-            y = clpy.ElementwiseKernel(
-                'raw int32 x', 'int32 y', 'y = x.strides()[i]',
-                'test_carray_strides',
-            )(x, size=2)
-            testing.assert_array_equal(y, (12, 4))
+    def test_strides(self):
+        x = clpy.arange(6).reshape((2, 3)).astype('i')
+        y = clpy.ElementwiseKernel(
+            'raw int32 x', 'int32 y', 'y = x.strides()[i]',
+            'test_carray_strides',
+        )(x, size=2)
+        testing.assert_array_equal(y, (12, 4))
 
     def test_getitem_int(self):
         x = clpy.arange(24).reshape((2, 3, 4)).astype('i')

--- a/tests/clpy_tests/opencl_tests/test_carray.py
+++ b/tests/clpy_tests/opencl_tests/test_carray.py
@@ -55,9 +55,9 @@ class TestCArraywithChunk(unittest.TestCase):
         expected = numpy.zeros(actual.shape, dtype=dtype)
         for i in range(expected.shape[0]):
             for j in range(expected.shape[1]):
-                # data.mem.offset divided by size of int32 (= 4 byte)
-                expected[i][j] = x.data.mem.offset / \
-                    4 + i * expected.shape[1] + j
+                # shapes multiplied by size of int32 (= 4 byte)
+                expected[i][j] = x.data.mem.offset \
+                    + (i * expected.shape[1] + j) * 4
 
         self.assertTrue(numpy.allclose(actual, expected))
 

--- a/ultima/ultima.cpp
+++ b/ultima/ultima.cpp
@@ -1166,8 +1166,14 @@ public:
       }
       else if(base_type->getDecl()->getName() == "CArray"){
         auto raw = clang::dyn_cast<clang::DeclRefExpr>(dig_expr(base));
-        if(member_expr->getMemberNameInfo().getAsString() == "size")
-          throw std::runtime_error("Current ultima doesn't support CArray::size().");
+        if(member_expr->getMemberNameInfo().getAsString() == "size"){
+          if(raw == nullptr)
+            throw std::runtime_error("Current ultima only support calling CArray::size() with a CArray object.");
+          os << "((const size_t)";
+          Visit(raw);
+          os << "_info.size_)";
+          return;
+        }
         else if(member_expr->getMemberNameInfo().getAsString() == "shape"){
           if(raw == nullptr)
             throw std::runtime_error("Current ultima only support calling CArray::shape() with a CArray object.");


### PR DESCRIPTION
This is a task of #51.

This PR contains below changes: 
- `CArray_n::strides_` has number of bytes instead of number of elements.
    - NumPy's and Cupy's `ndarray.strides` have number of bytes. CuPy's `CArray` also has that. We should follow them.
    - This change affects the result of `get_CArrayIndex` family, so this PR contains fix for an affected test case.
- `CArray_n` obtains new data member `size_` .
- Add support for `CArray::strides()` and `CArray::size()` .
