### PR TITLE
Make Ultima Build Time Shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ $ export CPLUS_INCLUDE_PATH=/usr/lib/llvm-6.0/include:$CPLUS_INCLUDE_PATH
 ### Install ClPy
 
 After OpenCL and LLVM/Clang is successfully installed, install ClPy.
+ClPy uses `make` command in build process, so if you do not have `make` , please install it before install ClPy.
 
 ```console
 $ pip install cython

--- a/clpy/core/carray.pxi
+++ b/clpy/core/carray.pxi
@@ -156,9 +156,16 @@ cpdef function.Module compile_with_cache(
     filename = tempfile.gettempdir() + "/" + str(time.monotonic()) + ".cpp"
 
     with TempFile(filename, source) as tf:
-        proc = subprocess.Popen('{0}/ultima/ultima {1} -- '
-                                '-I {0}/clpy/core/include'
-                                .format(clpy.__path__[0]+"/../", filename)
+        root_dir = os.path.join(clpy.__path__[0], "..")
+        proc = subprocess.Popen('{} {} -- -I {}'
+                                .format(os.path.join(root_dir,
+                                                     "ultima",
+                                                     "ultima"),
+                                        filename,
+                                        os.path.join(root_dir,
+                                                     "clpy",
+                                                     "core",
+                                                     "include"))
                                 .strip().split(" "),
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,

--- a/clpy_setup_build.py
+++ b/clpy_setup_build.py
@@ -24,14 +24,7 @@ is_clang_built_with_cxx11_abi = subprocess.Popen(
     shell=True).wait() == 0
 
 if subprocess.Popen(
-        'clang++ -std=c++11 -D_GLIBCXX_USE_CXX11_ABI={} -Wall -Wextra '
-        '-O3 -pedantic-errors ultima.cpp -lclangTooling -lclangFrontendTool '
-        '-lclangFrontend -lclangDriver -lclangSerialization -lclangCodeGen '
-        '-lclangParse -lclangSema -lclangStaticAnalyzerFrontend '
-        '-lclangStaticAnalyzerCheckers -lclangStaticAnalyzerCore '
-        '-lclangAnalysis -lclangARCMigrate -lclangRewrite -lclangEdit '
-        '-lclangAST -lclangLex -lclangBasic -lclang '
-        '`llvm-config --libs --system-libs` -fno-rtti -o ultima'
+        'make use_cxx11_abi:={}'
         .format(1 if is_clang_built_with_cxx11_abi else 0),
         cwd=os.path.dirname(__file__)+"/ultima",
         shell=True).wait() != 0:

--- a/clpy_setup_build.py
+++ b/clpy_setup_build.py
@@ -26,7 +26,7 @@ is_clang_built_with_cxx11_abi = subprocess.Popen(
 ultima_build_process = subprocess.Popen(
     'make use_cxx11_abi:={}'
     .format(1 if is_clang_built_with_cxx11_abi else 0),
-    cwd=os.path.dirname(__file__)+"/ultima",
+    cwd=os.path.join(os.path.dirname(__file__), "ultima"),
     shell=True)
 
 print("building headercvt")

--- a/clpy_setup_build.py
+++ b/clpy_setup_build.py
@@ -16,19 +16,18 @@ from install import utils
 import locale
 import subprocess
 
-print("building ultima")
+print("building ultima started")
 
 is_clang_built_with_cxx11_abi = subprocess.Popen(
     'nm $(dirname $(readlink -f `which clang++`))/../lib/libclangTooling.a'
     ' | grep -q __cxx11',
     shell=True).wait() == 0
 
-if subprocess.Popen(
-        'make use_cxx11_abi:={}'
-        .format(1 if is_clang_built_with_cxx11_abi else 0),
-        cwd=os.path.dirname(__file__)+"/ultima",
-        shell=True).wait() != 0:
-    raise RuntimeError('Build ultima is failed.')
+ultima_build_process = subprocess.Popen(
+    'make use_cxx11_abi:={}'
+    .format(1 if is_clang_built_with_cxx11_abi else 0),
+    cwd=os.path.dirname(__file__)+"/ultima",
+    shell=True)
 
 print("building headercvt")
 if subprocess.Popen(
@@ -77,6 +76,8 @@ def launch_headercvt():
 
 launch_headercvt()
 
+if ultima_build_process.wait() != 0:
+    raise RuntimeError('Build ultima is failed.')
 
 required_cython_version = pkg_resources.parse_version('0.24.0')
 ignore_cython_versions = [

--- a/ultima/Makefile
+++ b/ultima/Makefile
@@ -1,0 +1,5 @@
+ultima: ultima.cpp
+	clang++ -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=$(use_cxx11_abi) -Wall -Wextra -O3 -pedantic-errors $< -lclangTooling -lclangFrontendTool -lclangFrontend -lclangDriver -lclangSerialization -lclangCodeGen -lclangParse -lclangSema -lclangStaticAnalyzerFrontend -lclangStaticAnalyzerCheckers -lclangStaticAnalyzerCore -lclangAnalysis -lclangARCMigrate -lclangRewrite -lclangEdit -lclangAST -lclangLex -lclangBasic -lclang `llvm-config --libs --system-libs` -fno-rtti -o $@
+
+clean:
+	rm ultima 2>/dev/null || true


### PR DESCRIPTION
Current ultima is built on `clpy_setup_build.py` directly.
There is no problem for ClPy users.
However, ClPy developers who build ClPy many times are required patience for ultima build time.

This PR contains below changes:
- Ultima meets `make`
    - If there is no change in `ultima.cpp` , building ultima is skipped.
- Async build
    - Now headercvt and ultima are built in parallel.
- refactoring