### PR TITLE
Correct version specification of numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup_requires = [
     'fastrlock>=0.3',
 ]
 install_requires = [
-    'numpy>=1.9.0',
+    'numpy<=1.15.4,>=1.9.0',
     'six>=1.9.0',
     'fastrlock>=0.3',
 ]


### PR DESCRIPTION
works for https://github.com/fixstars/clpy/pull/140#issuecomment-457432807
- 'numpy>=1.9.0' to 'numpy<=1.15.4,>=1.9.0'