### PR TITLE
Add tests/clpy_tests/random_tests/test_distributions.py to test files on jenkins

### DIFF
--- a/jenkins/build_and_test.sh
+++ b/jenkins/build_and_test.sh
@@ -74,6 +74,7 @@ tests/clpy_tests/linalg_tests/test_product.py
 tests/clpy_tests/logic_tests/test_comparison.py
 tests/clpy_tests/logic_tests/test_ops.py
 tests/clpy_tests/logic_tests/test_type_test.py
+tests/clpy_tests/random_tests/test_distributions.py
 tests/clpy_tests/sorting_tests/test_count.py
 tests/clpy_tests/statics_tests/test_correlation.py
 tests/clpy_tests/statics_tests/test_meanvar.py


### PR DESCRIPTION
Work for #109 

Although clpy_tests/random_tests/test_distributions.py passes, this test has not been  added to test files  on jenkins.

Therefore, add it.