### PR TITLE
 Add math test which pass pytest without modification of contents to Jenkins test file.

### DIFF
--- a/jenkins/build_and_test.sh
+++ b/jenkins/build_and_test.sh
@@ -74,6 +74,9 @@ tests/clpy_tests/linalg_tests/test_product.py
 tests/clpy_tests/logic_tests/test_comparison.py
 tests/clpy_tests/logic_tests/test_ops.py
 tests/clpy_tests/logic_tests/test_type_test.py
+tests/clpy_tests/math_tests/test_explog.py
+tests/clpy_tests/math_tests/test_floating.py
+tests/clpy_tests/math_tests/test_window.py
 tests/clpy_tests/random_tests/test_distributions.py
 tests/clpy_tests/sorting_tests/test_count.py
 tests/clpy_tests/statics_tests/test_correlation.py


### PR DESCRIPTION
Work for #108 , https://github.com/fixstars/clpy/pull/131#issuecomment-448973254

Add some tests (about math_tests) to test files on jenkins.
These tests cleared pytest without changing content.

- tests/clpy_tests/math_tests/test_explog.py
- tests/clpy_tests/math_tests/test_floating.py
- tests/clpy_tests/math_tests/test_window.py