### PR TITLE
Add math test which pass pytest with modification of contents to Jenkins test file.

### DIFF
--- a/jenkins/build_and_test.sh
+++ b/jenkins/build_and_test.sh
@@ -74,8 +74,13 @@ tests/clpy_tests/linalg_tests/test_product.py
 tests/clpy_tests/logic_tests/test_comparison.py
 tests/clpy_tests/logic_tests/test_ops.py
 tests/clpy_tests/logic_tests/test_type_test.py
+tests/clpy_tests/math_tests/test_arithmetic.py
 tests/clpy_tests/math_tests/test_explog.py
 tests/clpy_tests/math_tests/test_floating.py
+tests/clpy_tests/math_tests/test_hyperbolic.py
+tests/clpy_tests/math_tests/test_misc.py
+tests/clpy_tests/math_tests/test_rounding.py
+tests/clpy_tests/math_tests/test_trigonometric.py
 tests/clpy_tests/math_tests/test_window.py
 tests/clpy_tests/random_tests/test_distributions.py
 tests/clpy_tests/sorting_tests/test_count.py

--- a/tests/clpy_tests/math_tests/test_arithmetic.py
+++ b/tests/clpy_tests/math_tests/test_arithmetic.py
@@ -28,27 +28,27 @@ class TestArithmetic(unittest.TestCase):
         b = testing.shaped_reverse_arange((2, 3), xp, dtype)
         return getattr(xp, name)(a, b)
 
-    @testing.for_dtypes(['?', 'b', 'h', 'i', 'q', 'e', 'f', 'd', 'F', 'D'])
+    @testing.for_dtypes(['?', 'b', 'h', 'i', 'q', 'f', 'd'])
     @testing.numpy_clpy_allclose(atol=1e-5)
     def check_unary_negative(self, name, xp, dtype):
         a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype)
         return getattr(xp, name)(a)
 
-    @testing.for_dtypes(['?', 'b', 'h', 'i', 'q', 'e', 'f', 'd', 'F', 'D'])
+    @testing.for_dtypes(['?', 'b', 'h', 'i', 'q', 'f', 'd'])
     @testing.numpy_clpy_allclose(atol=1e-4)
     def check_binary_negative(self, name, xp, dtype):
         a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype)
         b = xp.array([4, 3, 2, 1, -1, -2], dtype=dtype)
         return getattr(xp, name)(a, b)
 
-    @testing.for_dtypes(['?', 'b', 'h', 'i', 'q', 'e', 'f', 'd'])
+    @testing.for_dtypes(['?', 'b', 'h', 'i', 'q', 'f', 'd'])
     @testing.numpy_clpy_allclose(atol=1e-4)
     def check_binary_negative_no_complex(self, name, xp, dtype):
         a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype)
         b = xp.array([4, 3, 2, 1, -1, -2], dtype=dtype)
         return getattr(xp, name)(a, b)
 
-    @testing.for_dtypes(['e', 'f', 'd'])
+    @testing.for_dtypes(['f', 'd'])
     @testing.numpy_clpy_allclose(atol=1e-5)
     def check_binary_negative_float(self, name, xp, dtype):
         a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype)

--- a/tests/clpy_tests/math_tests/test_hyperbolic.py
+++ b/tests/clpy_tests/math_tests/test_hyperbolic.py
@@ -14,7 +14,7 @@ class TestHyperbolic(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return getattr(xp, name)(a)
 
-    @testing.for_dtypes(['e', 'f', 'd'])
+    @testing.for_dtypes(['f', 'd'])
     @testing.numpy_clpy_allclose(atol=1e-5)
     def check_unary_unit(self, name, xp, dtype):
         a = xp.array([0.2, 0.4, 0.6, 0.8], dtype=dtype)
@@ -32,7 +32,7 @@ class TestHyperbolic(unittest.TestCase):
     def test_arcsinh(self):
         self.check_unary('arcsinh')
 
-    @testing.for_dtypes(['e', 'f', 'd'])
+    @testing.for_dtypes(['f', 'd'])
     @testing.numpy_clpy_allclose(atol=1e-5)
     def test_arccosh(self, xp, dtype):
         a = xp.array([1, 2, 3], dtype=dtype)

--- a/tests/clpy_tests/math_tests/test_misc.py
+++ b/tests/clpy_tests/math_tests/test_misc.py
@@ -29,7 +29,7 @@ class TestMisc(unittest.TestCase):
         b = testing.shaped_reverse_arange((2, 3), xp, dtype)
         return getattr(xp, name)(a, b)
 
-    @testing.for_dtypes(['?', 'b', 'h', 'i', 'q', 'e', 'f', 'd'])
+    @testing.for_dtypes(['?', 'b', 'h', 'i', 'q', 'f', 'd'])
     @testing.numpy_clpy_allclose(atol=1e-5)
     def check_unary_negative(self, name, xp, dtype, no_bool=False):
         if no_bool and numpy.dtype(dtype).char == '?':

--- a/tests/clpy_tests/math_tests/test_rounding.py
+++ b/tests/clpy_tests/math_tests/test_rounding.py
@@ -14,7 +14,7 @@ class TestRounding(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         return getattr(xp, name)(a)
 
-    @testing.for_dtypes(['?', 'b', 'h', 'i', 'q', 'e', 'f', 'd'])
+    @testing.for_dtypes(['?', 'b', 'h', 'i', 'q', 'f', 'd'])
     @testing.numpy_clpy_allclose(atol=1e-5)
     def check_unary_negative(self, name, xp, dtype):
         a = xp.array([-3, -2, -1, 1, 2, 3], dtype=dtype)

--- a/tests/clpy_tests/math_tests/test_trigonometric.py
+++ b/tests/clpy_tests/math_tests/test_trigonometric.py
@@ -21,7 +21,7 @@ class TestTrigonometric(unittest.TestCase):
         b = testing.shaped_reverse_arange((2, 3), xp, dtype)
         return getattr(xp, name)(a, b)
 
-    @testing.for_dtypes(['e', 'f', 'd'])
+    @testing.for_dtypes(['f', 'd'])
     @testing.numpy_clpy_allclose(atol=1e-5)
     def check_unary_unit(self, name, xp, dtype):
         a = xp.array([0.2, 0.4, 0.6, 0.8], dtype=dtype)


### PR DESCRIPTION
Work for #108 , #131 (comment)

Add math test which pass pytest with modification of contents to Jenkins test file.

- tests/clpy_tests/math_tests/test_arithmetic.py
- tests/clpy_tests/math_tests/test_hyperbolic.py
- tests/clpy_tests/math_tests/test_misc.py
- tests/clpy_tests/math_tests/test_rounding.py
- tests/clpy_tests/math_tests/test_trigonometric.py