### PR TITLE
Remove WaitForEvents to improve performance

### DIFF
--- a/clpy/backend/opencl/utility.pyx
+++ b/clpy/backend/opencl/utility.pyx
@@ -138,7 +138,6 @@ cdef RunNDRangeKernel(
         event_wait_list=event_wait_list,
         event=&event[0]
     )
-    api.WaitForEvents(1, &event[0])
 
 cdef __device_typeof_size():
     host_size_t_bits = cython.sizeof(Py_ssize_t)*8


### PR DESCRIPTION
Remove a needless wait which is originally inserted for debugging.
I tested modified ClPy's performance on `train_mnist.py` example program of Chainer,
As a result, a total elapsed time for 20 epochs decreases from 99.76 sec to 79.46 sec on Tesla P100.