### PR TITLE
Add logic test which pass pytest to Jenkins test file.

### DIFF
--- a/jenkins/build_and_test.sh
+++ b/jenkins/build_and_test.sh
@@ -72,6 +72,7 @@ tests/clpy_tests/core_tests/test_userkernel.py
 tests/clpy_tests/indexing_tests/test_insert.py
 tests/clpy_tests/linalg_tests/test_product.py
 tests/clpy_tests/logic_tests/test_comparison.py
+tests/clpy_tests/logic_tests/test_content.py
 tests/clpy_tests/logic_tests/test_ops.py
 tests/clpy_tests/logic_tests/test_type_test.py
 tests/clpy_tests/math_tests/test_arithmetic.py

--- a/tests/clpy_tests/logic_tests/test_content.py
+++ b/tests/clpy_tests/logic_tests/test_content.py
@@ -10,14 +10,14 @@ class TestContent(unittest.TestCase):
 
     _multiprocess_can_split_ = True
 
-    @testing.for_dtypes('efFdD')
+    @testing.for_dtypes('fd')
     @testing.numpy_clpy_array_equal()
     def check_unary_inf(self, name, xp, dtype):
         a = xp.array([-3, numpy.inf, -1, -numpy.inf, 0, 1, 2],
                      dtype=dtype)
         return getattr(xp, name)(a)
 
-    @testing.for_dtypes('efFdD')
+    @testing.for_dtypes('fd')
     @testing.numpy_clpy_array_equal()
     def check_unary_nan(self, name, xp, dtype):
         a = xp.array(


### PR DESCRIPTION
Work for #83 and https://github.com/fixstars/clpy/pull/131#issuecomment-448973254

Add logic test to test files on jenkins.
In this test, purge unsupported features (half-float and complex)

- tests/clpy_tests/logic_tests/test_content.py