### PR TITLE
Add indexing test which pass pytest to Jenkins TEST_FILE.

### DIFF
--- a/clpy/__init__.py
+++ b/clpy/__init__.py
@@ -308,10 +308,10 @@ from numpy import typename  # NOQA
 # -----------------------------------------------------------------------------
 # Indexing routines
 # -----------------------------------------------------------------------------
-# from clpy.indexing.generate import c_  # NOQA
+from clpy.indexing.generate import c_  # NOQA
 from clpy.indexing.generate import indices  # NOQA
-# from clpy.indexing.generate import ix_  # NOQA
-# from clpy.indexing.generate import r_  # NOQA
+from clpy.indexing.generate import ix_  # NOQA
+from clpy.indexing.generate import r_  # NOQA
 
 # from clpy.indexing.indexing import choose  # NOQA
 # from clpy.indexing.indexing import diagonal  # NOQA

--- a/clpy/core/core.pyx
+++ b/clpy/core/core.pyx
@@ -4227,7 +4227,7 @@ def _nonzero_1d_kernel(src_dtype, index_dtype):
     __kernel void ${name}(const CArray<${src_dtype}, 1> src,
         const CArray<${index_dtype}, 1> scaned_index,
         CArray<${index_dtype}, 1> dst){
-        int thid = get_group_id(0) * get_local_size(0) + get_local_id(0);
+        int thid = get_global_id(0);
         ptrdiff_t n = src.size();
         if (thid < n){
             if (src[thid] != 0){

--- a/clpy/core/core.pyx
+++ b/clpy/core/core.pyx
@@ -4224,10 +4224,10 @@ def _nonzero_1d_kernel(src_dtype, index_dtype):
     index_dtype = _get_typename(index_dtype)
 
     source = string.Template("""
-    extern "C" __global__ void ${name}(const CArray<${src_dtype}, 1> src,
+    __kernel void ${name}(const CArray<${src_dtype}, 1> src,
         const CArray<${index_dtype}, 1> scaned_index,
         CArray<${index_dtype}, 1> dst){
-        int thid = blockIdx.x * blockDim.x + threadIdx.x;
+        int thid = get_group_id(0) * get_local_size(0) + get_local_id(0);
         ptrdiff_t n = src.size();
         if (thid < n){
             if (src[thid] != 0){

--- a/jenkins/build_and_test.sh
+++ b/jenkins/build_and_test.sh
@@ -69,6 +69,7 @@ tests/clpy_tests/core_tests/test_ndarray_unary_op.py
 tests/clpy_tests/core_tests/test_reduction.py
 tests/clpy_tests/core_tests/test_scan.py
 tests/clpy_tests/core_tests/test_userkernel.py
+tests/clpy_tests/indexing_tests/test_generate.py
 tests/clpy_tests/indexing_tests/test_insert.py
 tests/clpy_tests/linalg_tests/test_product.py
 tests/clpy_tests/logic_tests/test_comparison.py


### PR DESCRIPTION
Work for #79.

Add indexing test to Jenkins TEST_FILE.
to pass pytest, rewrite some code  CUDA to OpenCL-like.

- tests/clpy_tests/indexing_tests/test_generate.py