### PR TITLE
Multiple contexts for multiple devices

### DIFF
--- a/clpy/backend/memory.pyx
+++ b/clpy/backend/memory.pyx
@@ -290,8 +290,9 @@ cdef class MemoryPointer:
             else:
                 tmp = libc.stdlib.malloc(size)
                 with src.device:
+                    queue = clpy.backend.opencl.env.get_command_queue()
                     clpy.backend.opencl.api.EnqueueReadBuffer(
-                        command_queue=clpy.backend.opencl.env.get_command_queue(),
+                        command_queue=queue,
                         buffer=src.buf.ptr,
                         blocking_read=clpy.backend.opencl.api.BLOCKING,
                         offset=src.cl_mem_offset(),
@@ -301,8 +302,9 @@ cdef class MemoryPointer:
                         event_wait_list=<cl_event*>NULL,
                         event=<cl_event*>NULL)
                 with self.device:
+                    queue = clpy.backend.opencl.env.get_command_queue()
                     clpy.backend.opencl.api.EnqueueWriteBuffer(
-                        command_queue=clpy.backend.opencl.env.get_command_queue(),
+                        command_queue=queue,
                         buffer=self.buf.ptr,
                         blocking_write=clpy.backend.opencl.api.BLOCKING,
                         offset=self.cl_mem_offset(),
@@ -312,7 +314,6 @@ cdef class MemoryPointer:
                         event_wait_list=<cl_event*>NULL,
                         event=<cl_event*>NULL)
                 libc.stdlib.free(tmp)
-
 
     cpdef copy_from_device_async(self, MemoryPointer src, size_t size, stream):
         """Copies a memory from a (possibly different) device asynchronously.

--- a/clpy/backend/memory.pyx
+++ b/clpy/backend/memory.pyx
@@ -277,16 +277,18 @@ cdef class MemoryPointer:
         cdef void* tmp
         if size > 0:
             if src.device == self.device:
-                clpy.backend.opencl.api.EnqueueCopyBuffer(
-                    command_queue=clpy.backend.opencl.env.get_command_queue(),
-                    src_buffer=src.buf.ptr,
-                    dst_buffer=self.buf.ptr,
-                    src_offset=src.cl_mem_offset(),
-                    dst_offset=self.cl_mem_offset(),
-                    cb=size,
-                    num_events_in_wait_list=0,
-                    event_wait_list=<cl_event*>NULL,
-                    event=<cl_event*>NULL)
+                with self.device:
+                    queue = clpy.backend.opencl.env.get_command_queue()
+                    clpy.backend.opencl.api.EnqueueCopyBuffer(
+                        command_queue=queue,
+                        src_buffer=src.buf.ptr,
+                        dst_buffer=self.buf.ptr,
+                        src_offset=src.cl_mem_offset(),
+                        dst_offset=self.cl_mem_offset(),
+                        cb=size,
+                        num_events_in_wait_list=0,
+                        event_wait_list=<cl_event*>NULL,
+                        event=<cl_event*>NULL)
             else:
                 tmp = libc.stdlib.malloc(size)
                 with src.device:

--- a/clpy/backend/memory.pyx
+++ b/clpy/backend/memory.pyx
@@ -337,16 +337,17 @@ cdef class MemoryPointer:
         """
         cdef size_t host_ptr = mem.value
         if size > 0:
-            clpy.backend.opencl.api.EnqueueWriteBuffer(
-                command_queue=clpy.backend.opencl.env.get_command_queue(),
-                buffer=self.buf.ptr,
-                blocking_write=clpy.backend.opencl.api.BLOCKING,
-                offset=self.cl_mem_offset(),
-                cb=size,
-                host_ptr=<void*>host_ptr,
-                num_events_in_wait_list=0,
-                event_wait_list=<cl_event*>NULL,
-                event=<cl_event*>NULL)
+            with self.device:
+                clpy.backend.opencl.api.EnqueueWriteBuffer(
+                    command_queue=clpy.backend.opencl.env.get_command_queue(),
+                    buffer=self.buf.ptr,
+                    blocking_write=clpy.backend.opencl.api.BLOCKING,
+                    offset=self.cl_mem_offset(),
+                    cb=size,
+                    host_ptr=<void*>host_ptr,
+                    num_events_in_wait_list=0,
+                    event_wait_list=<cl_event*>NULL,
+                    event=<cl_event*>NULL)
 
     cpdef copy_from_host_async(self, mem, size_t size, stream):
         """Copies a memory sequence from the host memory asynchronously.
@@ -409,16 +410,17 @@ cdef class MemoryPointer:
         """
         cdef size_t host_ptr = mem.value
         if size > 0:
-            clpy.backend.opencl.api.EnqueueReadBuffer(
-                command_queue=clpy.backend.opencl.env.get_command_queue(),
-                buffer=self.buf.ptr,
-                blocking_read=clpy.backend.opencl.api.BLOCKING,
-                offset=self.cl_mem_offset(),
-                cb=size,
-                host_ptr=<void*>host_ptr,
-                num_events_in_wait_list=0,
-                event_wait_list=<cl_event*>NULL,
-                event=<cl_event*>NULL)
+            with self.device:
+                clpy.backend.opencl.api.EnqueueReadBuffer(
+                    command_queue=clpy.backend.opencl.env.get_command_queue(),
+                    buffer=self.buf.ptr,
+                    blocking_read=clpy.backend.opencl.api.BLOCKING,
+                    offset=self.cl_mem_offset(),
+                    cb=size,
+                    host_ptr=<void*>host_ptr,
+                    num_events_in_wait_list=0,
+                    event_wait_list=<cl_event*>NULL,
+                    event=<cl_event*>NULL)
 
     cpdef copy_to_host_async(self, mem, size_t size, stream):
         """Copies a memory sequence to the host memory asynchronously.

--- a/clpy/core/carray.pxi
+++ b/clpy/core/carray.pxi
@@ -186,11 +186,12 @@ cpdef function.Module compile_with_cache(
     options += (' -cl-fp32-correctly-rounded-divide-sqrt', )
     optionStr = functools.reduce(operator.add, options)
 
+    device = clpy.backend.opencl.env.get_device()
     program = clpy.backend.opencl.utility.CreateProgram(
         [source.encode('utf-8')],
         clpy.backend.opencl.env.get_context(),
-        clpy.backend.opencl.env.num_devices,
-        clpy.backend.opencl.env.get_devices(),
+        1,
+        &device,
         optionStr.encode('utf-8'))
     cdef function.Module module = function.Module()
     module.set(program)


### PR DESCRIPTION
#160 was unsufficient. As OpenCL spec says, a buffer created by using a context created for multiple devices (i.e. two or more `num_devices` on [`clCreateContext()`](https://www.khronos.org/registry/OpenCL/sdk/2.0/docs/man/xhtml/clCreateContext.html)) is shared among the devices. (cf. [thread on khronos forum](https://forums.khronos.org/showthread.php/7315-CreateBuffer-for-Multiple-Devices)).

This could cause waste memory usage. Moreover for ClPy, that behaiver could generate mistakes, errors, bugs because it's different from CUDA.

For those reasons, ClPy must use [multiple contexts, multiple devices model](https://www.cvg.ethz.ch/teaching/2011spring/gpgpu/GPU-multi-device.pdf), which creates each one context for each one devices respectively.

This also resolved issue #172.