### PR TITLE
[Only For CI] test_fusion.py Overwrites Input Arguments

### DIFF
--- a/tests/clpy_tests/core_tests/test_elementwise.py
+++ b/tests/clpy_tests/core_tests/test_elementwise.py
@@ -5,7 +5,7 @@ import six
 
 import clpy
 from clpy import backend
-# from clpy.backend.opencl.exceptions import OpenCLProgramBuildError
+from clpy.backend.opencl.exceptions import OpenCLProgramBuildError
 from clpy.backend.ultima.exceptions import UltimaRuntimeError
 from clpy import core
 from clpy import testing
@@ -606,15 +606,15 @@ class TestElementwiseRaiseExceptions(unittest.TestCase):
                 'undeclared_identifier',
                 'use_of_undeclared_indentifier')(x)
 
-#    def test_assign_to_const_qualified_variable(self):
-#        with six.assertRaisesRegex(self, OpenCLProgramBuildError,
-#                                   'cannot assign|is not assignable'):
-#            x = clpy.core.array(numpy.array([1], dtype="float32"))
-#            clpy.ElementwiseKernel(
-#                'T x',
-#                'T y',
-#                'x = y',
-#                'assign_to_const_qualified_variable')(x)
+    def test_assign_to_const_qualified_variable(self):
+        with six.assertRaisesRegex(self, OpenCLProgramBuildError,
+                                   'cannot assign|is not assignable'):
+            x = clpy.core.array(numpy.array([1], dtype="float32"))
+            clpy.ElementwiseKernel(
+                'T x',
+                'T y',
+                'x = y',
+                'assign_to_const_qualified_variable')(x)
 
 
 if __name__ == "__main__":

--- a/ultima/ultima.cpp
+++ b/ultima/ultima.cpp
@@ -2877,11 +2877,10 @@ public:
           const bool is_raw = x.find("raw ", clpy_arg_tag_length) == clpy_arg_tag_length;
           const auto name_end = std::min(x.find(' ', tag_prefix_length), x.size());
           const auto var_name = x.substr(tag_prefix_length, name_end - tag_prefix_length);
-          //const bool is_input = x.find("const", name_end) != std::string::npos;
+          const bool is_input = x.find("const", name_end) != std::string::npos;
           if(!template_type || template_type->getTemplateName().getAsTemplateDecl()->getQualifiedNameAsString() != "CArray")
             throw std::runtime_error("invalid \"clpy_arg\" annotation (it is only for CArray argument)");
-          //TODO: Add const(is_input == true) if it should be
-          carray_argument(template_type, var_name, is_raw, false);
+          carray_argument(template_type, var_name, is_raw, is_input);
           return;
         }
         else if(!parameter && x == "clpy_elementwise_tag"){


### PR DESCRIPTION
This PR is just a proof of validity for #131 by running CI , and is not for merging.

This PR fails `test_fusion.py::TestFusionUfunc` and `test_fusion.py::TestFusionFuse` because fusion overwrites input arguments.