### PR TITLE
Fix Headercvt for Some Environments

### DIFF
--- a/headercvt/headercvt.cpp
+++ b/headercvt/headercvt.cpp
@@ -195,6 +195,11 @@ public:
       Out << "# union declaration(" << D->getName() << ") ignored\n";
       return;
     }
+    const std::regex pthread_detector(R"(.*pthread.*)");
+    if(std::regex_match(D->getNameAsString(), pthread_detector)) {
+      Out << "# pthread-related type ignored\n";
+      return;
+    }
 
     Indent();
     Out << "cdef " << D->getKindName() << " " << D->getName() << ":\n";


### PR DESCRIPTION
Current `headercvt` outputs invalid Cython files on some environments (like our Old Primary machine) like below:

```cython
    cdef struct __pthread_cond_s:
        union __pthread_cond_s::(anonymous at /usr/include/x86_64-linux-gnu/bits/thread-shared-types.h:153:17)
        union __pthread_cond_s::(anonymous at /usr/include/x86_64-linux-gnu/bits/thread-shared-types.h:162:17)
        unsigned int __g_refs[2]
        unsigned int __g_size[2]
        unsigned int __g1_orig_size
        unsigned int __wrefs
        unsigned int __g_signals[2]
```

At first, we don't need `pthread`-related types in `types.pxi` .
So, we should remove it.
Current headercvt has a mechanism to detect-and-ignore `pthread`-related types ([like this](https://github.com/fixstars/clpy/blob/ffeec5131dc06dbf29f532033174ce72c5d3183b/headercvt/headercvt.cpp#L243-L248)), but the area of the mechanism seems to be not enough.

This PR makes the area of the mechanism extended and fix the problem on installing ClPy.