### PR TITLE
Support ROCm

### DIFF
--- a/clpy/core/carray.pxi
+++ b/clpy/core/carray.pxi
@@ -146,7 +146,9 @@ class TempFile(object):
 
 cpdef function.Module compile_with_cache(
         str source, tuple options=(), arch=None, cachd_dir=None):
-    source = _clpy_header + '\n' \
+    kernel_arg_size_t_code = 'typedef ' \
+        + clpy.backend.opencl.utility.typeof_size() + ' __kernel_arg_size_t;\n'
+    source = kernel_arg_size_t_code + _clpy_header + '\n' \
         'static void __clpy_begin_print_out() ' \
         '__attribute__((annotate("clpy_begin_print_out")));\n' \
         + source + '\n' \
@@ -188,7 +190,7 @@ cpdef function.Module compile_with_cache(
 
     device = clpy.backend.opencl.env.get_device()
     program = clpy.backend.opencl.utility.CreateProgram(
-        [source.encode('utf-8')],
+        [(kernel_arg_size_t_code + source).encode('utf-8')],
         clpy.backend.opencl.env.get_context(),
         1,
         &device,

--- a/clpy/core/elementwise.pxi
+++ b/clpy/core/elementwise.pxi
@@ -181,7 +181,7 @@ cpdef _get_kernel_params(tuple params, tuple args_info):
             t = 'CIndexer<%d>' % ndim
             ndims[name] = ndim
         elif type is Size_t:
-            t = 'kernel_arg_size_t'
+            t = '__kernel_arg_size_t'
         elif type is LocalMem:
             t = '__local _type_reduce* const __restrict__'
         else:
@@ -301,7 +301,7 @@ cdef class ParameterInfo:
             pass
         elif t == 'LocalMem':
             pass
-        elif t == 'kernel_arg_size_t':
+        elif t == '__kernel_arg_size_t':
             self.dtype = numpy.intp
             self.ctype = clpy.backend.opencl.utility.typeof_size()
         elif len(t) == 1:

--- a/clpy/core/include/clpy/carray.clh
+++ b/clpy/core/include/clpy/carray.clh
@@ -283,9 +283,9 @@ __device__ int signbit(float16 x) {return x.signbit();}
 
 #define CREATE_CINDXER(_NDIM) \
 typedef struct { \
-  size_t size_; \
-  size_t shape_[_NDIM]; \
-  size_t index_[_NDIM]; \
+  __kernel_arg_size_t size_; \
+  __kernel_arg_size_t shape_[_NDIM]; \
+  __kernel_arg_size_t index_[_NDIM]; \
 } CIndexer_##_NDIM; \
 \
 static size_t size_CIndexer_##_NDIM(const CIndexer_##_NDIM * const __restrict__ _ind) { \
@@ -303,7 +303,7 @@ static void set_CIndexer_##_NDIM(CIndexer_##_NDIM * const __restrict__ _ind, con
 }
 
 typedef struct {
-  size_t size_;
+  __kernel_arg_size_t size_;
 } CIndexer_0;
 static size_t size_CIndexer_0(const CIndexer_0 * const __restrict__ _ind) {
   return _ind->size_;
@@ -312,9 +312,9 @@ static void set_CIndexer_0(CIndexer_0 * const __restrict__ _ind, const size_t i)
 }
 
 typedef struct {
-  size_t size_;
-  size_t shape_[1];
-  size_t index_[1];
+  __kernel_arg_size_t size_;
+  __kernel_arg_size_t shape_[1];
+  __kernel_arg_size_t index_[1];
 } CIndexer_1;
 static size_t size_CIndexer_1(const CIndexer_1 * const __restrict__ _ind) {
   return _ind->size_;
@@ -344,10 +344,10 @@ CREATE_CINDXER(15)
 
 #define CREATE_CARRAY(_NDIM) \
 typedef struct { \
-  size_t offset; \
-  size_t size_; \
-  size_t shape_[_NDIM]; \
-  size_t strides_[_NDIM]; \
+  __kernel_arg_size_t offset; \
+  __kernel_arg_size_t size_; \
+  __kernel_arg_size_t shape_[_NDIM]; \
+  __kernel_arg_size_t strides_[_NDIM]; \
 } CArray_##_NDIM; \
 size_t get_CArrayIndexI_##_NDIM(const CArray_##_NDIM* const __restrict__ info, const size_t i) { \
   size_t offset = info->offset; \
@@ -361,8 +361,8 @@ size_t get_CArrayIndexI_##_NDIM(const CArray_##_NDIM* const __restrict__ info, c
 }
 
 typedef struct {
-  size_t offset;
-  size_t size_;
+  __kernel_arg_size_t offset;
+  __kernel_arg_size_t size_;
 } CArray_0;
 static size_t get_CArrayIndexRaw_0(const CArray_0* const __restrict__ info, const ptrdiff_t idx) {
   return info->offset;
@@ -375,10 +375,10 @@ static size_t get_CArrayIndexI_0(const CArray_0* const __restrict__ info, const 
 }
 
 typedef struct {
-  size_t offset;
-  size_t size_;
-  size_t shape_;
-  size_t strides_;
+  __kernel_arg_size_t offset;
+  __kernel_arg_size_t size_;
+  __kernel_arg_size_t shape_;
+  __kernel_arg_size_t strides_;
 } CArray_1;
 static size_t get_CArrayIndexRaw_1(const CArray_1* const __restrict__ info, const ptrdiff_t idx) {
   return info->strides_ * (size_t)idx + info->offset;

--- a/clpy/core/reduction.pxi
+++ b/clpy/core/reduction.pxi
@@ -19,7 +19,6 @@ cpdef _get_simple_reduction_kernel(
         identity = '0'
 
     module_code = string.Template(string.Template('''
-    typedef ${typeof_size} __kernel_arg_size_t;
     ${type_preamble}
     ${preamble}
     #define REDUCE(a, b) (${reduce_expr})
@@ -88,7 +87,6 @@ cpdef _get_simple_reduction_kernel(
         output_expr=output_expr,
         output_store=output_store,
         preamble=preamble,
-        typeof_size=clpy.backend.opencl.utility.typeof_size(),
         clpy_variables_declaration=clpy_variables_declaration)
     module = compile_with_cache(module_code, options)
     return module.get_function(name)

--- a/clpy/core/reduction.pxi
+++ b/clpy/core/reduction.pxi
@@ -19,7 +19,7 @@ cpdef _get_simple_reduction_kernel(
         identity = '0'
 
     module_code = string.Template(string.Template('''
-    typedef ${typeof_size} kernel_arg_size_t;
+    typedef ${typeof_size} __kernel_arg_size_t;
     ${type_preamble}
     ${preamble}
     #define REDUCE(a, b) (${reduce_expr})
@@ -197,7 +197,7 @@ class simple_reduction_function(object):
             in_params + out_params +
             _get_param_info(
                 'CIndexer _in_ind, CIndexer _out_ind', False) +
-            _get_param_info('kernel_arg_size_t _local_stride', True) +
+            _get_param_info('__kernel_arg_size_t _local_stride', True) +
             _get_param_info('LocalMem _sdata', True))
         self._input_expr = \
             '__attribute__((annotate("clpy_simple_reduction_tag:in"))) ' \
@@ -384,7 +384,7 @@ class ReductionKernel(object):
         self.params = (
             self.in_params + self.out_params +
             _get_param_info('CIndexer _in_ind, CIndexer _out_ind', False) +
-            _get_param_info('kernel_arg_size_t _local_stride', True) +
+            _get_param_info('__kernel_arg_size_t _local_stride', True) +
             _get_param_info('LocalMem _sdata', True))
         self.identity = identity
         self.reduce_expr = reduce_expr


### PR DESCRIPTION
Current ClPy doesn't work on OpenCL C compiler of [ROCm](https://rocm.github.io/), [clang-ocl](https://github.com/RadeonOpenCompute/clang-ocl/tree/roc-2.2.0).

In OpenCL C, we can't use type `size_t` for `__kernel` function parameter.
Most of the OpenCL C compilers raise a compilation error when using `size_t` on function parameter directly, but they cannot detect to use a `struct`ure which consists of `size_t` members. (It seems that OpenCL C specification does not mention about this situation.)
However, clang-ocl can detect to use `size_t` both directly and indirectly. Additionally, current ClPy uses indirect `size_t` parameter: `CArray_n` and `CIndexer_n` , in `<clpy/carray.clh>` .
`<clpy/carray.clh>` is `include`d automatically, so current ClPy does not run on ROCm.

So, this PR add new global `typedef` , `__kernel_arg_size_t` , in kernel.
`__kernel_arg_size_t` alters as unsigned integer type which has same size as `size_t` of host/device.
Furthermore, all `size_t` members of `CArray_n` and `CIndexer_n` are replaced with `__kernel_arg_size_t` , and `kernel_arg_size_t` in elementwise/reduction kernel of current ClPy is also replaced with `__kernel_arg_size_t`.
This PR makes ClPy to support ROCm.