### PR TITLE
Remove Waiting from Batched sgemm/dgemm

### DIFF
--- a/clpy/backend/function.pyx
+++ b/clpy/backend/function.pyx
@@ -14,7 +14,6 @@ cimport clpy.backend.opencl.api
 cimport clpy.backend.opencl.utility
 import clpy.backend.opencl.env
 cimport clpy.backend.opencl.env
-from clpy.backend.opencl.types cimport cl_event
 import clpy.core
 
 cdef inline size_t _get_stream(strm) except *:
@@ -129,10 +128,7 @@ cdef void _launch(clpy.backend.opencl.types.cl_kernel kernel, global_work_size,
         work_dim=global_dim,  # asserted to be equal to local_dim
         global_work_offset=<size_t*>NULL,
         global_work_size=&gws[0],
-        local_work_size=lws_ptr,
-        num_events_in_wait_list=0,
-        event_wait_list=<cl_event*>NULL,
-        event=NULL)
+        local_work_size=lws_ptr)
 
 
 cdef class Function:

--- a/clpy/backend/memory.pyx
+++ b/clpy/backend/memory.pyx
@@ -20,7 +20,6 @@ import clpy.backend.opencl
 cimport clpy.backend.opencl.utility
 import clpy.backend.opencl.env
 cimport clpy.backend.opencl.env
-from clpy.backend.opencl.types cimport cl_event
 from clpy.backend.opencl.types cimport cl_mem
 
 cimport libc.stdlib
@@ -285,10 +284,7 @@ cdef class MemoryPointer:
                         dst_buffer=self.buf.ptr,
                         src_offset=src.cl_mem_offset(),
                         dst_offset=self.cl_mem_offset(),
-                        cb=size,
-                        num_events_in_wait_list=0,
-                        event_wait_list=<cl_event*>NULL,
-                        event=<cl_event*>NULL)
+                        cb=size)
             else:
                 tmp = libc.stdlib.malloc(size)
                 with src.device:
@@ -299,10 +295,7 @@ cdef class MemoryPointer:
                         blocking_read=clpy.backend.opencl.api.BLOCKING,
                         offset=src.cl_mem_offset(),
                         cb=size,
-                        host_ptr=tmp,
-                        num_events_in_wait_list=0,
-                        event_wait_list=<cl_event*>NULL,
-                        event=<cl_event*>NULL)
+                        host_ptr=tmp)
                 with self.device:
                     queue = clpy.backend.opencl.env.get_command_queue()
                     clpy.backend.opencl.api.EnqueueWriteBuffer(
@@ -311,10 +304,7 @@ cdef class MemoryPointer:
                         blocking_write=clpy.backend.opencl.api.BLOCKING,
                         offset=self.cl_mem_offset(),
                         cb=size,
-                        host_ptr=tmp,
-                        num_events_in_wait_list=0,
-                        event_wait_list=<cl_event*>NULL,
-                        event=<cl_event*>NULL)
+                        host_ptr=tmp)
                 libc.stdlib.free(tmp)
 
     cpdef copy_from_device_async(self, MemoryPointer src, size_t size, stream):
@@ -347,10 +337,7 @@ cdef class MemoryPointer:
                     blocking_write=clpy.backend.opencl.api.BLOCKING,
                     offset=self.cl_mem_offset(),
                     cb=size,
-                    host_ptr=<void*>host_ptr,
-                    num_events_in_wait_list=0,
-                    event_wait_list=<cl_event*>NULL,
-                    event=<cl_event*>NULL)
+                    host_ptr=<void*>host_ptr)
 
     cpdef copy_from_host_async(self, mem, size_t size, stream):
         """Copies a memory sequence from the host memory asynchronously.
@@ -420,10 +407,7 @@ cdef class MemoryPointer:
                     blocking_read=clpy.backend.opencl.api.BLOCKING,
                     offset=self.cl_mem_offset(),
                     cb=size,
-                    host_ptr=<void*>host_ptr,
-                    num_events_in_wait_list=0,
-                    event_wait_list=<cl_event*>NULL,
-                    event=<cl_event*>NULL)
+                    host_ptr=<void*>host_ptr)
 
     cpdef copy_to_host_async(self, mem, size_t size, stream):
         """Copies a memory sequence to the host memory asynchronously.
@@ -455,10 +439,7 @@ cdef class MemoryPointer:
                 pattern=&value,
                 pattern_size=sizeof(value),
                 offset=0,
-                size=size,
-                num_events_in_wait_list=0,
-                event_wait_list=<cl_event*>NULL,
-                event=<cl_event*>NULL)
+                size=size)
 
     cpdef memset_async(self, int value, size_t size, stream):
         """Fills a memory sequence by constant byte value asynchronously.

--- a/clpy/backend/opencl/api.pxd
+++ b/clpy/backend/opencl/api.pxd
@@ -64,9 +64,9 @@ cdef void SetKernelArg(cl_kernel kernel,
 cdef void EnqueueTask(
     cl_command_queue command_queue,
     cl_kernel kernel,
-    cl_uint num_events_in_wait_list,
-    cl_event* event_wait_list,
-    cl_event* event) except *
+    cl_uint num_events_in_wait_list=*,
+    cl_event* event_wait_list=*,
+    cl_event* event=*) except *
 cdef void EnqueueNDRangeKernel(
     cl_command_queue command_queue,
     cl_kernel kernel,
@@ -74,9 +74,9 @@ cdef void EnqueueNDRangeKernel(
     size_t* global_work_offset,
     size_t* global_work_size,
     size_t* local_work_size,
-    cl_uint num_events_in_wait_list,
-    cl_event* event_wait_list,
-    cl_event* event) except *
+    cl_uint num_events_in_wait_list=*,
+    cl_event* event_wait_list=*,
+    cl_event* event=*) except *
 cdef void EnqueueReadBuffer(
     cl_command_queue command_queue,
     cl_mem buffer,
@@ -84,9 +84,9 @@ cdef void EnqueueReadBuffer(
     size_t offset,
     size_t cb,
     void* host_ptr,
-    cl_uint num_events_in_wait_list,
-    cl_event* event_wait_list,
-    cl_event* event) except *
+    cl_uint num_events_in_wait_list=*,
+    cl_event* event_wait_list=*,
+    cl_event* event=*) except *
 cdef void EnqueueWriteBuffer(
     cl_command_queue command_queue,
     cl_mem buffer,
@@ -94,9 +94,9 @@ cdef void EnqueueWriteBuffer(
     size_t offset,
     size_t cb,
     void* host_ptr,
-    cl_uint num_events_in_wait_list,
-    cl_event* event_wait_list,
-    cl_event* event) except *
+    cl_uint num_events_in_wait_list=*,
+    cl_event* event_wait_list=*,
+    cl_event* event=*) except *
 cdef void EnqueueCopyBuffer(
     cl_command_queue command_queue,
     cl_mem src_buffer,
@@ -104,9 +104,9 @@ cdef void EnqueueCopyBuffer(
     size_t src_offset,
     size_t dst_offset,
     size_t cb,
-    cl_uint num_events_in_wait_list,
-    cl_event* event_wait_list,
-    cl_event* event) except *
+    cl_uint num_events_in_wait_list=*,
+    cl_event* event_wait_list=*,
+    cl_event* event=*) except *
 cdef void EnqueueFillBuffer(
     cl_command_queue command_queue,
     cl_mem buffer,
@@ -114,9 +114,9 @@ cdef void EnqueueFillBuffer(
     size_t pattern_size,
     size_t offset,
     size_t size,
-    cl_uint num_events_in_wait_list,
-    cl_event* event_wait_list,
-    cl_event* event) except *
+    cl_uint num_events_in_wait_list=*,
+    cl_event* event_wait_list=*,
+    cl_event* event=*) except *
 cdef void Flush(cl_command_queue command_queue) except *
 cdef void Finish(cl_command_queue command_queue) except *
 cdef void ReleaseKernel(cl_kernel kernel) except *

--- a/clpy/backend/opencl/api.pyx
+++ b/clpy/backend/opencl/api.pyx
@@ -177,9 +177,9 @@ cdef void SetKernelArg(cl_kernel kernel, arg_index, arg_size,
 cdef void EnqueueTask(
         cl_command_queue command_queue,
         cl_kernel kernel,
-        cl_uint num_events_in_wait_list,
-        cl_event* event_wait_list,
-        cl_event* event) except *:
+        cl_uint num_events_in_wait_list=0,
+        cl_event* event_wait_list=<cl_event*>NULL,
+        cl_event* event=<cl_event*>NULL) except *:
     cdef cl_int status = clEnqueueTask(
         command_queue,
         kernel,
@@ -194,9 +194,9 @@ cdef void EnqueueNDRangeKernel(
         size_t* global_work_offset,
         size_t* global_work_size,
         size_t* local_work_size,
-        cl_uint num_events_in_wait_list,
-        cl_event* event_wait_list,
-        cl_event* event) except *:
+        cl_uint num_events_in_wait_list=0,
+        cl_event* event_wait_list=<cl_event*>NULL,
+        cl_event* event=<cl_event*>NULL) except *:
 
     cdef cl_int status = clEnqueueNDRangeKernel(
         command_queue,
@@ -217,9 +217,9 @@ cdef void EnqueueReadBuffer(
         size_t offset,
         size_t cb,
         void* host_ptr,
-        cl_uint num_events_in_wait_list,
-        cl_event* event_wait_list,
-        cl_event* event) except *:
+        cl_uint num_events_in_wait_list=0,
+        cl_event* event_wait_list=<cl_event*>NULL,
+        cl_event* event=<cl_event*>NULL) except *:
     cdef cl_int status = clEnqueueReadBuffer(
         command_queue,
         buffer,
@@ -239,9 +239,9 @@ cdef void EnqueueWriteBuffer(
         size_t offset,
         size_t cb,
         void* host_ptr,
-        cl_uint num_events_in_wait_list,
-        cl_event* event_wait_list,
-        cl_event* event) except *:
+        cl_uint num_events_in_wait_list=0,
+        cl_event* event_wait_list=<cl_event*>NULL,
+        cl_event* event=<cl_event*>NULL) except *:
     cdef cl_int status = clEnqueueWriteBuffer(
         command_queue,
         buffer,
@@ -261,9 +261,9 @@ cdef void EnqueueCopyBuffer(
         size_t src_offset,
         size_t dst_offset,
         size_t cb,
-        cl_uint num_events_in_wait_list,
-        cl_event* event_wait_list,
-        cl_event* event) except *:
+        cl_uint num_events_in_wait_list=0,
+        cl_event* event_wait_list=<cl_event*>NULL,
+        cl_event* event=<cl_event*>NULL) except *:
     cdef cl_int status = clEnqueueCopyBuffer(
         command_queue,
         src_buffer,
@@ -283,9 +283,9 @@ cdef void EnqueueFillBuffer(
         size_t pattern_size,
         size_t offset,
         size_t size,
-        cl_uint num_events_in_wait_list,
-        cl_event* event_wait_list,
-        cl_event* event) except *:
+        cl_uint num_events_in_wait_list=0,
+        cl_event* event_wait_list=<cl_event*>NULL,
+        cl_event* event=<cl_event*>NULL) except *:
     cdef cl_int status = clEnqueueFillBuffer(
         command_queue,
         buffer,

--- a/clpy/backend/opencl/clblast/clblast.pyx
+++ b/clpy/backend/opencl/clblast/clblast.pyx
@@ -232,7 +232,6 @@ cdef void clblast_sgemm_batched(
         size_t *c_offsets,
         size_t c_ld,
         size_t batch_count) except *:
-    cdef cl_event event = NULL
     cdef cl_command_queue\
         command_queue=clpy.backend.opencl.env.get_command_queue()
 
@@ -246,11 +245,8 @@ cdef void clblast_sgemm_batched(
         c_buffer, c_offsets, c_ld,
         batch_count,
         &command_queue,
-        &event)
-    if (status == CLBlastSuccess):
-        api.WaitForEvents(1, &event)
-        api.ReleaseEvent(event)
-    else:
+        <cl_event*>NULL)
+    if (status != CLBlastSuccess):
         raise CLBlastRuntimeError(statuscode=status)
     return
 
@@ -306,7 +302,6 @@ cdef void clblast_dgemm_batched(
         size_t *c_offsets,
         size_t c_ld,
         size_t batch_count) except *:
-    cdef cl_event event = NULL
     cdef cl_command_queue\
         command_queue=clpy.backend.opencl.env.get_command_queue()
 
@@ -320,11 +315,8 @@ cdef void clblast_dgemm_batched(
         c_buffer, c_offsets, c_ld,
         batch_count,
         &command_queue,
-        &event)
-    if (status == CLBlastSuccess):
-        api.WaitForEvents(1, &event)
-        api.ReleaseEvent(event)
-    else:
+        <cl_event*>NULL)
+    if (status != CLBlastSuccess):
         raise CLBlastRuntimeError(statuscode=status)
     return
 

--- a/clpy/testing/bufio.pyx
+++ b/clpy/testing/bufio.pyx
@@ -2,7 +2,6 @@ cimport clpy.backend.opencl.api
 import clpy.backend.opencl.api
 cimport clpy.backend.opencl.env
 from clpy.backend.memory cimport Buf
-from clpy.backend.opencl.types cimport cl_event
 
 cpdef writebuf(Buf buffer_to_write, n_bytes, host_ptr, offset=0):
     cdef size_t host_ptr_sizet = host_ptr
@@ -12,10 +11,7 @@ cpdef writebuf(Buf buffer_to_write, n_bytes, host_ptr, offset=0):
         clpy.backend.opencl.api.BLOCKING,
         offset,
         n_bytes,
-        <void*>host_ptr_sizet,
-        0,
-        <cl_event*>NULL,
-        <cl_event*>NULL)
+        <void*>host_ptr_sizet)
 
 cpdef readbuf(Buf buffer_to_read, n_bytes, host_ptr, offset=0):
     cdef size_t host_ptr_sizet = host_ptr
@@ -25,7 +21,4 @@ cpdef readbuf(Buf buffer_to_read, n_bytes, host_ptr, offset=0):
         clpy.backend.opencl.api.BLOCKING,
         offset,
         n_bytes,
-        <void*>host_ptr_sizet,
-        0,
-        <cl_event*>NULL,
-        <cl_event*>NULL)
+        <void*>host_ptr_sizet)


### PR DESCRIPTION
This PR contains below changes:
- Batched sgemm/dgemm are made wait-free

And also this PR contains below minor refactoring:
- Set default argument for`cl_event` parameter of `clpy.backend.opencl.api.EnqueueFooBar`
    - Current ClPy waits finishing kernels execution when [reading](https://github.com/fixstars/clpy/blob/1542f0b9f4d686e86f83a7446c7e87ac4c47ec56/clpy/backend/memory.pyx#L295)/[writing](https://github.com/fixstars/clpy/blob/1542f0b9f4d686e86f83a7446c7e87ac4c47ec56/clpy/backend/memory.pyx#L304) memory, so `cl_event` parameters are not used usually.