### PR TITLE
Support LLVM/Clang8

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ and add ldconfig on `/etc/ldconf.so.d/` and `$ sudo ldconfig`.
 
 ### Install LLVM/Clang
 
-Current ClPy requires LLVM/Clang 4.0, 5.0, 6.0, 7.0, or 8.0.
+Current ClPy requires LLVM/Clang 4, 5, 6, 7, or 8.
 We **strongly** recommend that you build LLVM/Clang from the source codes and install it.
 However, at least in Ubuntu 16.04, you can use the LLVM/Clang from the Ubuntu official package repository.
 In that case, you need to set `PATH` and `CPLUS_INCLUDE_PATH` environment variables like below.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ and add ldconfig on `/etc/ldconf.so.d/` and `$ sudo ldconfig`.
 
 ### Install LLVM/Clang
 
-Current ClPy requires LLVM/Clang 4.0, 5.0, 6.0, or 7.0.
+Current ClPy requires LLVM/Clang 4.0, 5.0, 6.0, 7.0, or 8.0.
 We **strongly** recommend that you build LLVM/Clang from the source codes and install it.
 However, at least in Ubuntu 16.04, you can use the LLVM/Clang from the Ubuntu official package repository.
 In that case, you need to set `PATH` and `CPLUS_INCLUDE_PATH` environment variables like below.

--- a/ultima/ultima.cpp
+++ b/ultima/ultima.cpp
@@ -187,6 +187,20 @@ class preprocessor : public pp_callbacks<clang::PPCallbacks>{
   }
 };
 
+namespace detail{
+
+template<typename PredefinedExpr>
+decltype(PredefinedExpr::getIdentTypeName(std::declval<PredefinedExpr>().getIdentType())) getIdentTypeName(PredefinedExpr* pe){
+  return PredefinedExpr::getIdentTypeName(pe->getIdentType());
+}
+
+template<typename PredefinedExpr>
+decltype(PredefinedExpr::getIdentKindName(std::declval<PredefinedExpr>().getIdentKind())) getIdentTypeName(PredefinedExpr* pe){
+  return PredefinedExpr::getIdentKindName(pe->getIdentKind());
+}
+
+}
+
 class decl_visitor;
 
 template<typename T>
@@ -655,7 +669,7 @@ public:
   }
 
   void VisitPredefinedExpr(clang::PredefinedExpr *Node) {
-    os << clang::PredefinedExpr::getIdentTypeName(Node->getIdentType());
+    os << detail::getIdentTypeName(Node);
   }
 
   void VisitCharacterLiteral(clang::CharacterLiteral *Node) {
@@ -671,7 +685,7 @@ public:
     llvm::SmallString<16> Str;
     Node->getValue().toString(Str);
     os << Str;
-    if (Str.find_first_not_of("-0123456789") == StringRef::npos)
+    if (Str.find_first_not_of("-0123456789") == llvm::StringRef::npos)
       os << '.'; // Trailing dot in order to separate from ints.
 
     if (!PrintSuffix)


### PR DESCRIPTION
Task of #213 .

ClPy in this PR supports LLVM/Clang 8.

Additionally, I confirmed current ClPy supports LLVM/Clang 7.1.0, so this PR removes required clang's minor versions `.0` on README.