### PR TITLE
Revert "Support Clang8"

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ and add ldconfig on `/etc/ldconf.so.d/` and `$ sudo ldconfig`.
 
 ### Install LLVM/Clang
 
-Current ClPy requires LLVM/Clang 4, 5, 6, 7, or 8.
+Current ClPy requires LLVM/Clang 4, 5, 6, or 7.
 We **strongly** recommend that you build LLVM/Clang from the source codes and install it.
 However, at least in Ubuntu 16.04, you can use the LLVM/Clang from the Ubuntu official package repository.
 In that case, you need to set `PATH` and `CPLUS_INCLUDE_PATH` environment variables like below.

--- a/ultima/ultima.cpp
+++ b/ultima/ultima.cpp
@@ -187,20 +187,6 @@ class preprocessor : public pp_callbacks<clang::PPCallbacks>{
   }
 };
 
-namespace detail{
-
-template<typename PredefinedExpr>
-decltype(PredefinedExpr::getIdentTypeName(std::declval<PredefinedExpr>().getIdentType())) getIdentTypeName(PredefinedExpr* pe){
-  return PredefinedExpr::getIdentTypeName(pe->getIdentType());
-}
-
-template<typename PredefinedExpr>
-decltype(PredefinedExpr::getIdentKindName(std::declval<PredefinedExpr>().getIdentKind())) getIdentTypeName(PredefinedExpr* pe){
-  return PredefinedExpr::getIdentKindName(pe->getIdentKind());
-}
-
-}
-
 class decl_visitor;
 
 template<typename T>
@@ -669,7 +655,7 @@ public:
   }
 
   void VisitPredefinedExpr(clang::PredefinedExpr *Node) {
-    os << detail::getIdentTypeName(Node);
+    os << clang::PredefinedExpr::getIdentTypeName(Node->getIdentType());
   }
 
   void VisitCharacterLiteral(clang::CharacterLiteral *Node) {
@@ -685,7 +671,7 @@ public:
     llvm::SmallString<16> Str;
     Node->getValue().toString(Str);
     os << Str;
-    if (Str.find_first_not_of("-0123456789") == llvm::StringRef::npos)
+    if (Str.find_first_not_of("-0123456789") == StringRef::npos)
       os << '.'; // Trailing dot in order to separate from ints.
 
     if (!PrintSuffix)


### PR DESCRIPTION
https://github.com/fixstars/clpy/issues/213#issuecomment-492618663

This reverts commit 314a6bcca427d631fb1f2e5d4b2747c8e7b2148a.

Note: I confirmed that current ClPy supports Clang 7.1.0, so I don't revert 77b4a52.