### PR TITLE
Fix no-mangle test case for ultima

### DIFF
--- a/tests/clpy_tests/opencl_tests/ultima_tests/test_overload.py
+++ b/tests/clpy_tests/opencl_tests/ultima_tests/test_overload.py
@@ -93,11 +93,20 @@ void f(int a)
 void f(double a) 
 {
 }
+int main() 
+{
+    f(42);
+    f(42.);
+}
 '''
         y = utility.exec_ultima(
             '''
             void f(int a){}
             __attribute__((annotate("clpy_no_mangle"))) void f(double a){}
+            int main(){
+              f(42);
+              f(42.);
+            }
             ''')
         self.assertEqual(x[1:], y)
 


### PR DESCRIPTION
In #235, I had added the test for function overloading of ultima.
However, I have thought that `test_no_mangle` should contain not only callees but also callers.

This PR fixes the test case.