### PR TITLE
Use clEnqueueMarker instead of clEnqueueBarrier

### DIFF
--- a/clpy/backend/opencl/api.pxd
+++ b/clpy/backend/opencl/api.pxd
@@ -117,6 +117,9 @@ cdef void EnqueueFillBuffer(
     cl_uint num_events_in_wait_list=*,
     cl_event* event_wait_list=*,
     cl_event* event=*) except *
+cdef void EnqueueMarker(
+    cl_command_queue command_queue,
+    cl_event* event) except *
 cdef void EnqueueBarrierWithWaitList(
     cl_command_queue command_queue,
     cl_uint num_events_in_wait_list=*,

--- a/clpy/backend/opencl/api.pyx
+++ b/clpy/backend/opencl/api.pyx
@@ -299,6 +299,14 @@ cdef void EnqueueFillBuffer(
         event)
     exceptions.check_status(status)
 
+cdef void EnqueueMarker(
+        cl_command_queue command_queue,
+        cl_event* event) except *:
+    cdef cl_int status = clEnqueueMarker(
+        command_queue,
+        event)
+    exceptions.check_status(status)
+
 cdef void EnqueueBarrierWithWaitList(
         cl_command_queue command_queue,
         cl_uint num_events_in_wait_list=0,

--- a/clpy/backend/opencl/utility.pyx
+++ b/clpy/backend/opencl/utility.pyx
@@ -176,10 +176,8 @@ def typeof_size():
 
 cpdef size_t eventRecord() except *:
     cdef cl_event event
-    api.EnqueueBarrierWithWaitList(
+    api.EnqueueMarker(
         env.get_command_queue(),
-        0,
-        NULL,
         &event)
     api.WaitForEvents(1, &event)
     cpdef size_t time


### PR DESCRIPTION
イベントオブジェクトの時刻測定のところで `clEnqueueBarrierWithWaitList` がなぜか titanv でうまく動かないので、
`clEnqueueMarker` に変更しました。