### PR TITLE
implement clpy.backend.compile_with_cache

### DIFF
--- a/clpy/backend/__init__.py
+++ b/clpy/backend/__init__.py
@@ -1,6 +1,6 @@
 import contextlib
 
-# from clpy.backend import compiler  # NOQA
+from clpy.backend import compiler  # NOQA
 from clpy.backend import device  # NOQA
 from clpy.backend import function  # NOQA
 from clpy.backend import memory  # NOQA
@@ -51,7 +51,7 @@ def is_available():
 
 
 # import class and function
-# from clpy.backend.compiler import compile_with_cache  # NOQA
+from clpy.backend.compiler import compile_with_cache  # NOQA
 from clpy.backend.device import Device  # NOQA
 from clpy.backend.device import get_cublas_handle  # NOQA
 from clpy.backend.device import get_device_id  # NOQA

--- a/clpy/backend/compiler.pxd
+++ b/clpy/backend/compiler.pxd
@@ -1,0 +1,5 @@
+import function
+cimport function
+
+cpdef function.Module compile_with_cache(
+    str source, tuple options=*, arch=*, cache_dir=*, extra_source=*)

--- a/clpy/backend/compiler.pyx
+++ b/clpy/backend/compiler.pyx
@@ -1,0 +1,23 @@
+import functools
+import operator
+cimport function
+
+cimport clpy.backend.opencl.env
+cimport clpy.backend.opencl.utility
+
+cpdef function.Module compile_with_cache(
+        str source, tuple options=(), arch=None, cache_dir=None,
+        extra_source=None):
+    options += (' -cl-fp32-correctly-rounded-divide-sqrt', )
+    optionStr = functools.reduce(operator.add, options)
+
+    device = clpy.backend.opencl.env.get_device()
+    program = clpy.backend.opencl.utility.CreateProgram(
+        [source.encode('utf-8')],
+        clpy.backend.opencl.env.get_context(),
+        1,
+        &device,
+        optionStr.encode('utf-8'))
+    cdef function.Module module = function.Module()
+    module.set(program)
+    return module

--- a/clpy/core/carray.pxi
+++ b/clpy/core/carray.pxi
@@ -145,7 +145,7 @@ class TempFile(object):
             os.remove(self.fn)
 
 cpdef function.Module compile_with_cache(
-        str source, tuple options=(), arch=None, cachd_dir=None):
+        str source, tuple options=(), arch=None, cache_dir=None):
     kernel_arg_size_t_code = 'typedef ' \
         + clpy.backend.opencl.utility.typeof_size() + ' __kernel_arg_size_t;\n'
     source = kernel_arg_size_t_code + _clpy_header + '\n' \

--- a/clpy/core/carray.pxi
+++ b/clpy/core/carray.pxi
@@ -1,5 +1,3 @@
-import functools
-import operator
 import os
 import subprocess
 import tempfile
@@ -8,11 +6,9 @@ import warnings
 
 
 from clpy import backend
-from clpy.backend cimport function
-# from clpy.backend cimport runtime
+import clpy.backend.compiler
+cimport clpy.backend.compiler
 cimport clpy.backend.opencl.api
-cimport clpy.backend.opencl.utility
-import clpy.backend.opencl.env
 cimport clpy.backend.opencl.env
 
 
@@ -185,16 +181,10 @@ cpdef function.Module compile_with_cache(
 
     extra_source = _get_header_source()
     options += ('-I%s' % _get_header_dir_path(),)
-    options += (' -cl-fp32-correctly-rounded-divide-sqrt', )
-    optionStr = functools.reduce(operator.add, options)
 
-    device = clpy.backend.opencl.env.get_device()
-    program = clpy.backend.opencl.utility.CreateProgram(
-        [(kernel_arg_size_t_code + source).encode('utf-8')],
-        clpy.backend.opencl.env.get_context(),
-        1,
-        &device,
-        optionStr.encode('utf-8'))
-    cdef function.Module module = function.Module()
-    module.set(program)
-    return module
+    return clpy.backend.compiler.compile_with_cache(
+        kernel_arg_size_t_code + source,
+        options,
+        arch,
+        cache_dir,
+        extra_source)

--- a/clpy_setup_build.py
+++ b/clpy_setup_build.py
@@ -95,6 +95,7 @@ MODULES = [
             # 'clpy.backend.cublas',
             # 'clpy.backend.curand',
             # 'clpy.backend.cusparse',
+            'clpy.backend.compiler',
             'clpy.backend.device',
             # 'clpy.backend.driver',
             'clpy.backend.memory',

--- a/examples/gemm/sgemm.cl
+++ b/examples/gemm/sgemm.cl
@@ -20,6 +20,8 @@ Licensed under modified BSD license
 //#define THR_N  ${THR_N}
 //#define THR_M  ${THR_M}
 
+#include<clpy/carray.clh>
+
 #define fetch(arr, offs, col, m, n, bound) arr[offs + (long)min((long)((n)*(col) + m), (long)bound)]
 
 

--- a/examples/gemm/sgemm.py
+++ b/examples/gemm/sgemm.py
@@ -8,6 +8,7 @@ import clpy as cp
 import numpy as np
 
 from utils import benchmark
+from utils import include_path
 from utils import load_kernel
 from utils import read_code
 
@@ -35,9 +36,10 @@ def sgemm(A, B,
               'BLK_M': blk_m, 'BLK_N': blk_n, 'BLK_K': blk_k,
               'DIM_XA': dim_xa, 'DIM_YA': dim_ya,
               'DIM_XB': dim_xb, 'DIM_YB': dim_yb,
-              'THR_M': blk_m // dim_x, 'THR_N': blk_n // dim_y}
+              'THR_M': blk_m // dim_x, 'THR_N': blk_n // dim_y,
+              '__kernel_arg_size_t': cp.backend.opencl.utility.typeof_size()}
     code = read_code(sgemm_file, params=config)
-    kern = load_kernel('sgemm', code)
+    kern = load_kernel('sgemm', code, ('-I{}'.format(include_path()),))
 
     grid = (int(math.ceil(m / blk_m)) * dim_x,
             int(math.ceil(n / blk_n)) * dim_y,

--- a/examples/gemm/utils.py
+++ b/examples/gemm/utils.py
@@ -1,10 +1,17 @@
 import clpy as cp
 
 
+import os
+
+
+def include_path():
+    return os.path.join(cp.__path__[0], "..", "clpy", "core", "include")
+
+
 @cp.util.memoize(for_each_device=True)
 def load_kernel(kernel_name, code, options=()):
     assert isinstance(options, tuple)
-    kernel_code = cp.core.core.compile_with_cache(code, options=options)
+    kernel_code = cp.backend.compile_with_cache(code, options=options)
     return kernel_code.get_function(kernel_name)
 
 


### PR DESCRIPTION
This is one of [the remaining tasks](https://github.com/fixstars/clpy/issues/216#issuecomment-531137926) of #216 .

## Change Points

- `clpy.backend.compile_with_cache` have been implemented.
    - `clpy.core.core.compile_with_cache` in this PR uses `clpy.backend.compile_with_cache` instead of `clpy.backend.opencl.*` directly.
- Replace `clpy.core.core.compile_with_cache` in `examples/gemm`  to `clpy.backend.compile_with_cache`