### PR TITLE
Support LLVM/Clang 8&9

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ In addition, add the needed ldconfig files to `/etc/ldconf.so.d/`, then execute 
 
 ### Install LLVM/Clang
 
-The current ClPy version requires LLVM/Clang 4, 5, 6, or 7.
+The current ClPy version requires LLVM/Clang 4, 5, 6, 7, or 8.
 We **strongly** recommend building and installing LLVM/Clang from source.
 However, at least in Ubuntu 16.04, you can use LLVM/Clang as provided by the Ubuntu official package repository.
 In that case, you will need to set `PATH` and `CPLUS_INCLUDE_PATH` environment variables as shown below.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ In addition, add the needed ldconfig files to `/etc/ldconf.so.d/`, then execute 
 
 ### Install LLVM/Clang
 
-The current ClPy version requires LLVM/Clang 4, 5, 6, 7, or 8.
+The current ClPy version requires LLVM/Clang 4, 5, 6, 7, 8, or 9.
 We **strongly** recommend building and installing LLVM/Clang from source.
 However, at least in Ubuntu 16.04, you can use LLVM/Clang as provided by the Ubuntu official package repository.
 In that case, you will need to set `PATH` and `CPLUS_INCLUDE_PATH` environment variables as shown below.

--- a/clpy/core/carray.pxi
+++ b/clpy/core/carray.pxi
@@ -175,7 +175,7 @@ cpdef function.Module compile_with_cache(
             proc.kill()
             source, errstream = proc.communicate()
 
-        if proc.returncode != 0 and len(errstream) > 0:
+        if proc.returncode != 0 or len(errstream) > 0:
             raise clpy.backend.ultima.exceptions.UltimaRuntimeError(
                 proc.returncode, errstream)
 

--- a/tests/clpy_tests/opencl_tests/ultima_tests/utility.py
+++ b/tests/clpy_tests/opencl_tests/ultima_tests/utility.py
@@ -54,7 +54,7 @@ def exec_ultima(source, _clpy_header=''):
             proc.kill()
             source, errstream = proc.communicate()
 
-        if proc.returncode != 0 and len(errstream) > 0:
+        if proc.returncode != 0 or len(errstream) > 0:
             raise clpy.backend.ultima.exceptions.UltimaRuntimeError(
                 proc.returncode, errstream)
 

--- a/ultima/ultima.cpp
+++ b/ultima/ultima.cpp
@@ -187,6 +187,20 @@ class preprocessor : public pp_callbacks<clang::PPCallbacks>{
   }
 };
 
+namespace detail{
+
+template<typename PredefinedExpr>
+decltype(PredefinedExpr::getIdentTypeName(std::declval<PredefinedExpr>().getIdentType())) getIdentTypeName(PredefinedExpr* pe){
+  return PredefinedExpr::getIdentTypeName(pe->getIdentType());
+}
+
+template<typename PredefinedExpr>
+decltype(PredefinedExpr::getIdentKindName(std::declval<PredefinedExpr>().getIdentKind())) getIdentTypeName(PredefinedExpr* pe){
+  return PredefinedExpr::getIdentKindName(pe->getIdentKind());
+}
+
+}
+
 class decl_visitor;
 
 template<typename T>
@@ -655,7 +669,7 @@ public:
   }
 
   void VisitPredefinedExpr(clang::PredefinedExpr *Node) {
-    os << clang::PredefinedExpr::getIdentTypeName(Node->getIdentType());
+    os << detail::getIdentTypeName(Node);
   }
 
   void VisitCharacterLiteral(clang::CharacterLiteral *Node) {
@@ -671,7 +685,7 @@ public:
     llvm::SmallString<16> Str;
     Node->getValue().toString(Str);
     os << Str;
-    if (Str.find_first_not_of("-0123456789") == StringRef::npos)
+    if (Str.find_first_not_of("-0123456789") == llvm::StringRef::npos)
       os << '.'; // Trailing dot in order to separate from ints.
 
     if (!PrintSuffix)

--- a/ultima/ultima.cpp
+++ b/ultima/ultima.cpp
@@ -62,7 +62,7 @@ struct ostreams{
   std::vector<llvm::raw_ostream*> oss;
   ostreams(llvm::raw_ostream& os):oss{&os}{}
   template<typename T>
-    llvm::raw_ostream& operator<<(T&& rhs){return (*oss.back()) << rhs;}
+  llvm::raw_ostream& operator<<(T&& rhs){return (*oss.back()) << rhs;}
   operator llvm::raw_ostream&(){return *oss.back();}
   void push(llvm::raw_ostream& os){oss.emplace_back(&os);}
   void pop(){oss.pop_back();}
@@ -190,12 +190,12 @@ class preprocessor : public pp_callbacks<clang::PPCallbacks>{
 namespace detail{
 
 template<typename PredefinedExpr>
-decltype(PredefinedExpr::getIdentTypeName(std::declval<PredefinedExpr>().getIdentType())) getIdentTypeName(PredefinedExpr* pe){
+static inline decltype(PredefinedExpr::getIdentTypeName(std::declval<PredefinedExpr>().getIdentType())) getIdentTypeName(PredefinedExpr* pe){
   return PredefinedExpr::getIdentTypeName(pe->getIdentType());
 }
 
 template<typename PredefinedExpr>
-decltype(PredefinedExpr::getIdentKindName(std::declval<PredefinedExpr>().getIdentKind())) getIdentTypeName(PredefinedExpr* pe){
+static inline decltype(PredefinedExpr::getIdentKindName(std::declval<PredefinedExpr>().getIdentKind())) getIdentTypeName(PredefinedExpr* pe){
   return PredefinedExpr::getIdentKindName(pe->getIdentKind());
 }
 

--- a/ultima/ultima.cpp
+++ b/ultima/ultima.cpp
@@ -199,6 +199,143 @@ decltype(PredefinedExpr::getIdentKindName(std::declval<PredefinedExpr>().getIden
   return PredefinedExpr::getIdentKindName(pe->getIdentKind());
 }
 
+template<typename GenericSelectionExpr>
+class generic_selection_expr_index{
+  GenericSelectionExpr* t;
+ public:
+  class iterator{
+    class accessor{
+      GenericSelectionExpr* t;
+      unsigned index;
+     public:
+      accessor() = default;
+      accessor(GenericSelectionExpr* ptr, unsigned ind):t{ptr}, index{ind}{}
+      accessor(const accessor&) = default;
+      accessor(accessor&&) = default;
+      clang::QualType get_type()const{
+        return t->getAssocType(index);
+      }
+      clang::Expr* get_expr()const{
+        return t->getAssocExpr(index);
+      }
+      friend class iterator;
+    }t;
+   public:
+    iterator() = default;
+    iterator(GenericSelectionExpr* ptr, unsigned ind):t{ptr, ind}{}
+    iterator(const iterator&) = default;
+    iterator(iterator&&) = default;
+    iterator& operator++()noexcept{
+      ++t.index;
+      return *this;
+    }
+    iterator operator++(int){
+      iterator it = *this;
+      ++t.index;
+      return it;
+    }
+    bool operator==(const iterator& other)const{
+      return t.index == other.t.index;
+    }
+    bool operator!=(const iterator& other)const{
+      return !(*this == other);
+    }
+    accessor& operator*()noexcept{
+      return t;
+    }
+    const accessor& operator*()const noexcept{
+      return t;
+    }
+    accessor* operator->()noexcept{
+      return &t;
+    }
+    const accessor* operator->()const noexcept{
+      return &t;
+    }
+  };
+  constexpr generic_selection_expr_index(GenericSelectionExpr* ptr):t{ptr}{}
+  iterator begin()const{return iterator{t, 0u};}
+  iterator end()const{return iterator{t, t->getNumAssocs()};}
+};
+
+template<typename GenericSelectionExpr>
+class generic_selection_expr_iterator{
+  GenericSelectionExpr* t;
+ public:
+  class iterator{
+    class accessor{
+      typename GenericSelectionExpr::AssociationIterator t;
+     public:
+      accessor() = default;
+      accessor(const typename GenericSelectionExpr::AssociationIterator& it):t{it}{}
+      accessor(const accessor&) = default;
+      accessor(accessor&&) = default;
+      clang::QualType get_type()const{
+        return t->getType();
+      }
+      clang::Expr* get_expr()const{
+        return t->getAssociationExpr();
+      }
+      friend class iterator;
+    }t;
+   public:
+    iterator() = default;
+    iterator(typename GenericSelectionExpr::AssociationIterator itr):t{itr}{}
+    iterator(const iterator&) = default;
+    iterator(iterator&&) = default;
+    iterator& operator++()noexcept{
+      ++t.t;
+      return *this;
+    }
+    iterator operator++(int){
+      iterator it = *this;
+      ++t.t;
+      return it;
+    }
+    bool operator==(const iterator& other)const{
+      return t.t == other.t.t;
+    }
+    bool operator!=(const iterator& other)const{
+      return !(*this == other);
+    }
+    accessor& operator*()noexcept{
+      return t;
+    }
+    const accessor& operator*()const noexcept{
+      return t;
+    }
+    accessor* operator->()noexcept{
+      return &t;
+    }
+    const accessor* operator->()const noexcept{
+      return &t;
+    }
+  };
+  constexpr generic_selection_expr_iterator(GenericSelectionExpr* ptr):t{ptr}{}
+  iterator begin()const{return iterator{t->associations().begin()};}
+  iterator end()const{return iterator{t->associations().end()};}
+};
+
+template<typename GenericSelectionExpr, typename std::enable_if<std::is_same<clang::QualType, decltype(std::declval<GenericSelectionExpr>().getAssocType(0u))>::value, std::nullptr_t>::type = nullptr>
+static constexpr generic_selection_expr_index<GenericSelectionExpr> generic_selection_expr_wrapper(GenericSelectionExpr* t){
+  return {t};
+}
+template<typename GenericSelectionExpr, typename std::enable_if<std::is_same<clang::QualType, decltype(std::declval<GenericSelectionExpr>().associations().begin()->getType())>::value, std::nullptr_t>::type = nullptr>
+static constexpr generic_selection_expr_iterator<GenericSelectionExpr> generic_selection_expr_wrapper(GenericSelectionExpr* t){
+  return {t};
+}
+
+template<typename CXXNewExpr, typename std::enable_if<std::is_same<clang::Expr*, decltype(std::declval<CXXNewExpr>().getArraySize())>::value, std::nullptr_t>::type = nullptr>
+static inline clang::Expr* get_array_size(CXXNewExpr* node){
+   return node->getArraySize();
+}
+
+template<typename CXXNewExpr, typename std::enable_if<std::is_same<clang::Optional<clang::Expr*>, decltype(std::declval<CXXNewExpr>().getArraySize())>::value, std::nullptr_t>::type = nullptr>
+static inline clang::Expr* get_array_size(CXXNewExpr* node){
+   auto e = node->getArraySize();
+   return e ? *e : nullptr;
+}
+
 }
 
 class decl_visitor;
@@ -810,15 +947,16 @@ public:
   void VisitGenericSelectionExpr(clang::GenericSelectionExpr *Node) {
     os << "_Generic(";
     PrintExpr(Node->getControllingExpr());
-    for (unsigned i = 0; i != Node->getNumAssocs(); ++i) {
+    auto node = ultima::detail::generic_selection_expr_wrapper(Node);
+    for (auto&& x : node) {
       os << ", ";
-      auto T = Node->getAssocType(i);
+      auto T = x.get_type();
       if (T.isNull())
         os << "default";
       else
         T.print(os, Policy);
       os << ": ";
-      PrintExpr(Node->getAssocExpr(i));
+      PrintExpr(x.get_expr());
     }
     os << ')';
   }
@@ -1613,7 +1751,7 @@ public:
     if (E->isParenTypeId())
       os << '(';
     std::string TypeS;
-    if (clang::Expr *Size = E->getArraySize()) {
+    if (clang::Expr *Size = ultima::detail::get_array_size(E)) {
       llvm::raw_string_ostream s(TypeS);
       s << '[';
       Visit(Size);


### PR DESCRIPTION
[NKT...](https://dic.nicovideo.jp/a/nkt)

This is a task of #213 .
This PR contains below changes:

- Support Clang 8 & 9
    - **Fix [the problem that ultima blow off her work](https://github.com/fixstars/clpy/issues/213#issuecomment-492618663) when she has been built with Clang 8 or newer**
    - Add some workarounds for Clang 8 and 9
- [Fix error handling of `clpy.core.core.compile_with_cache`](https://github.com/fixstars/clpy/issues/213#issuecomment-538908642)
- (petit) refactoring