### PR TITLE
remove cl_khr_fp16

### DIFF
--- a/clpy/core/include/cl_stub.hpp
+++ b/clpy/core/include/cl_stub.hpp
@@ -11,8 +11,6 @@ typedef unsigned long ulong;
 typedef unsigned long size_t;
 typedef long ptrdiff_t;
 
-typedef float half;
-typedef half __clpy__half;
 #define half __clpy__half
 
 __attribute__((annotate("clpy_no_mangle"))) static unsigned int atomic_cmpxchg(volatile __global unsigned int*, unsigned int, unsigned int);

--- a/clpy/core/include/clpy/carray.clh
+++ b/clpy/core/include/clpy/carray.clh
@@ -1,5 +1,4 @@
 #pragma once
-#pragma OPENCL EXTENSION cl_khr_fp16: enable
 
 // TODO: Implement common functions in OpenCL C
 #if 0

--- a/clpy/core/include/clpy/carray.clh
+++ b/clpy/core/include/clpy/carray.clh
@@ -530,54 +530,60 @@ static void __clpy_end_print_out() __attribute__((annotate("clpy_end_print_out")
 
 
 #ifdef __ULTIMA
-__attribute__((annotate("clpy_no_mangle"))) static half convert_float_to_half(float x);
-#else
-#include "fp16.clh"
-typedef half __clpy__half;
-#endif
+__attribute__((annotate("clpy_no_mangle"))) static ushort convert_float_to_half_ushort(float x);
+__attribute__((annotate("clpy_no_mangle"))) static float convert_half_ushort_to_float(ushort x);
 
-#ifdef __ULTIMA
-__attribute__((annotate("clpy_no_mangle"))) static half clpy_nextafter_fp16(half x1, half x2);
-#else
-static int isnan_fp16(half x){
-  unsigned short const* x_raw = (unsigned short const*)&x;
-  return (*x_raw & 0x7c00u) == 0x7c00u && (*x_raw & 0x03ffu) != 0x0000u;
+static void __clpy_begin_print_out() __attribute__((annotate("clpy_begin_print_out")));
+
+typedef struct __attribute__((packed)) __attribute__((aligned(2))) __clpy__half_{
+  ushort v;
+  __clpy__half_() = default;
+  __clpy__half_(float f):v{convert_float_to_half_ushort(f)}{}
+}__clpy__half;
+
+static int isnan_fp16(__clpy__half x){
+  return (x.v & 0x7c00u) == 0x7c00u && (x.v & 0x03ffu) != 0x0000u;
 }
-static int isfinite_fp16(half x){
-  unsigned short const* x_raw = (unsigned short const*)&x;
-  return (*x_raw & 0x7c00u) != 0x7c00u;
+static int isfinite_fp16(__clpy__half x){
+  return (x.v & 0x7c00u) != 0x7c00u;
 }
-static int iszero_fp16(half x){
-  unsigned short const* x_raw = (unsigned short const*)&x;
-  return (*x_raw & 0x7fffu) == 0;
+static int iszero_fp16(__clpy__half x){
+  return (x.v & 0x7fffu) == 0;
 }
-static int eq_nonan_fp16(half x1, half x2){
-  unsigned short const* x1_raw = (unsigned short const*)&x1;
-  unsigned short const* x2_raw = (unsigned short const*)&x2;
-  return (*x1_raw == *x2_raw || ((*x1_raw | *x2_raw) & 0x7fff) == 0);
+static int eq_nonan_fp16(__clpy__half x1, __clpy__half x2){
+  return (x1.v == x2.v || ((x1.v | x2.v) & 0x7fff) == 0);
 }
-static half clpy_nextafter_fp16(half x1, half x2){
-  unsigned short const* x1_raw = (unsigned short const*)&x1;
-  unsigned short const* x2_raw = (unsigned short const*)&x2;
+__attribute__((annotate("clpy_no_mangle"))) static __clpy__half clpy_nextafter_fp16(__clpy__half x1, __clpy__half x2){
   unsigned short ret_raw_;
 
   if (!isfinite_fp16(x1) || isnan_fp16(x2)){
     ret_raw_ = 0x7e00u; // NaN in fp16
   }else if(eq_nonan_fp16(x1, x2)){
-    ret_raw_ = *x1_raw;
+    ret_raw_ = x1.v;
   }else if(iszero_fp16(x1)){
-    ret_raw_ = (*x2_raw & 0x8000u) + 1;
-  }else if(!(*x1_raw & 0x8000u)){
-    if (*(short const*)x1_raw > *(short const*)x2_raw){
-      ret_raw_ = *x1_raw - 1;
+    ret_raw_ = (x2.v & 0x8000u) + 1;
+  }else if(!(x1.v & 0x8000u)){
+    if (*(short const*)&x1.v > *(short const*)&x2.v){
+      ret_raw_ = x1.v - 1;
     }else{
-      ret_raw_ = *x1_raw + 1;
+      ret_raw_ = x1.v + 1;
     }
-  }else if(!(*x2_raw & 0x8000u) || (*x1_raw & 0x7fffu) > (*x2_raw & 0x7fffu)) {
-    ret_raw_ = *x1_raw - 1;
+  }else if(!(x2.v & 0x8000u) || (x1.v & 0x7fffu) > (x2.v & 0x7fffu)) {
+    ret_raw_ = x1.v - 1;
   } else {
-    ret_raw_ = *x1_raw + 1;
+    ret_raw_ = x1.v + 1;
   }
-  return *(half*)&ret_raw_;
+  __clpy__half ret;
+  ret.v = ret_raw_;
+  return ret;
 }
+
+__attribute__((annotate("clpy_no_mangle"))) static __clpy__half convert_float_to_half(float x){
+  __clpy__half ret(x);
+  return ret;
+}
+
+static void __clpy_end_print_out() __attribute__((annotate("clpy_end_print_out")));
+#else
+#include "fp16.clh"
 #endif

--- a/clpy/core/include/clpy/fp16.clh
+++ b/clpy/core/include/clpy/fp16.clh
@@ -12,7 +12,7 @@
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-static half convert_float_to_half(float f) {
+static ushort convert_float_to_half_ushort(float f) {
   const float scale_to_inf = 0x1.0p+112f;
   const float scale_to_zero = 0x1.0p-110f;
   float base = (fabs(f) * scale_to_inf) * scale_to_zero;
@@ -32,5 +32,26 @@ static half convert_float_to_half(float f) {
   const uint mantissa_bits = bits & (uint)(0x00000FFF);
   const uint nonsign = exp_bits + mantissa_bits;
   const ushort ret = ((sign >> 16) | (shl1_w > (uint)(0xFF000000) ? (ushort)(0x7E00) : nonsign));
-  return *(const half*)&ret;
+  return ret;
+}
+
+static inline float convert_half_ushort_to_float(ushort h) {
+  const uint w = (uint) h << 16;
+  const uint sign = w & (uint)0x80000000;
+  const uint two_w = w + w;
+
+  const uint exp_offset = (uint)0xE0 << 23;
+  const float exp_scale = 0x1.0p-112f;
+  const uint normalized_value_ = (two_w >> 4) + exp_offset;
+  const float normalized_value = *(const float*)&normalized_value_ * exp_scale;
+
+  const uint magic_mask = (uint)(126u) << 23;
+  const float magic_bias = .5f;
+  const uint denormalized_value_ = (two_w >> 17) | magic_mask;
+  const float denormalized_value = *(const float*)&denormalized_value_ - magic_bias;
+
+  const uint denormalized_cutoff = (uint)1u << 27;
+  const uint result = sign |
+    *(const uint*)(two_w < denormalized_cutoff ? &denormalized_value : &normalized_value);
+  return *(const float*)&result;
 }

--- a/tests/clpy_tests/opencl_tests/ultima_tests/test_half.py
+++ b/tests/clpy_tests/opencl_tests/ultima_tests/test_half.py
@@ -10,21 +10,22 @@ import unittest
 class TestUltimaHalfTrick(unittest.TestCase):
 
     def test_type_half(self):
-        x = '''
+        x = clpy.backend.ultima.exec_ultima('', '#include <cupy/carray.hpp>') + ('''
 __clpy__half f() 
 {
-    __clpy__half a;
-    return (__clpy__half)(42.F);
+    __clpy__half a;constructor___clpy__half___left_paren____clpy__half_float__right_paren__(&a, 42.F);
+    return a;
 }
-'''
+''')[1:]
         y = clpy.backend.ultima.exec_ultima(
             '''
             half f(){
-              half a;
-              return static_cast<half>(42.f);
+              half a = 42.f;
+              return a;
             }
-            ''')
-        self.assertEqual(x[1:], y)
+            ''',
+            '#include <cupy/carray.hpp>')
+        self.assertEqual(x, y)
 
     def test_variable_named_half(self):
         x = '''
@@ -54,21 +55,20 @@ void f(int __clpy__half)
         self.assertEqual(x[1:], y)
 
     def test_clpy_half(self):
-        x = '''
+        x = clpy.backend.ultima.exec_ultima('', '#include <cupy/carray.hpp>') + ('''
 void f() 
 {
-    __clpy__half half_ = 42.F;
-    int __clpy__half = half_;
+    int __clpy__half = 42;
 }
-'''
+''')[1:]
         y = clpy.backend.ultima.exec_ultima(
             '''
             void f(){
-              __clpy__half half_ = 42.f;
-              int __clpy__half = half_;
+              int __clpy__half = 42;
             }
-            ''')
-        self.assertEqual(x[1:], y)
+            ''',
+            '#include <cupy/carray.hpp>')
+        self.assertEqual(x, y)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A task of #264 .

In this PR, `__clpy__half` has been implemented. This doesn't require `cl_khr_fp16` , so that extension has been removed.
ClPy in this PR gives up to support type casting to `half` , but currently we doesn't support `half` type, so it makes little impact.

