### PR TITLE
Support continue on ElementwiseKernel

### DIFF
--- a/clpy/core/elementwise.pxi
+++ b/clpy/core/elementwise.pxi
@@ -26,11 +26,13 @@ cpdef _get_simple_elementwise_kernel(
       ${loop_prep};
       // TODO: Add offset and/or stride
       const size_t i = get_global_id(0);
-      __attribute__((annotate("clpy_elementwise_tag"))) \
-        void __clpy_elementwise_preprocess();
-      ${operation};
-      __attribute__((annotate("clpy_elementwise_tag"))) \
-        void __clpy_elementwise_postprocess();
+      do{
+        __attribute__((annotate("clpy_elementwise_tag"))) \
+          void __clpy_elementwise_preprocess();
+        ${operation};
+        __attribute__((annotate("clpy_elementwise_tag"))) \
+          void __clpy_elementwise_postprocess();
+      }while(0);
       ${after_loop};
     }
     ''').substitute(


### PR DESCRIPTION
@jinz2014 [revealed that current ClPy doesn't support `continue` on `ElementwiseKernel`](https://github.com/fixstars/clpy/issues/274).
We will need that [when we will update ClPy to v4](https://github.com/fixstars/clpy/issues/274#issuecomment-593206811).

ClPy in this PR supports `continue` syntax on `ElementwiseKernel` .

Note: The semantic of `break` is not same as CuPy's one, but I believe that no people use it...