### PR TITLE
Optimize _launch ndarray case by type declaration

### DIFF
--- a/clpy/backend/function.pyx
+++ b/clpy/backend/function.pyx
@@ -58,7 +58,7 @@ cdef void _launch(clpy.backend.opencl.types.cl_kernel kernel, global_work_size,
     cdef size_t i = 0
     cdef _CIndexer indexer  # to keep lifetime until SetKernelArg
     cdef _CArray arrayInfo  # to keep lifetime until SetKernelArg
-    cdef vector.vector[Py_ssize_t] shape, strides
+    cdef core.ndarray a_ndarray
     cdef size_t ndim = 0
     cdef size_t d = 0
     cdef size_t ptr = 0
@@ -73,23 +73,23 @@ cdef void _launch(clpy.backend.opencl.types.cl_kernel kernel, global_work_size,
 
     for a in args:
         if isinstance(a, core.ndarray):
-            buffer_object = a.data.buf.get()
+            a_ndarray = <core.ndarray>a
+
+            buffer_object = a_ndarray.data.buf.get()
             clpy.backend.opencl.api.SetKernelArg(kernel, i, sizeof(void*),
                                                  <void*>&buffer_object)
             i+=1
 
-            shape = a._shape
-            strides = a._strides
-            ndim = strides.size()
+            ndim = a_ndarray._strides.size()
             for d in range(ndim):
-                if strides[d] % a.itemsize != 0:
+                if a_ndarray._strides[d] % a.itemsize != 0:
                     raise ValueError("Stride of dim {0} = {1},"
                                      " but item size is {2}"
-                                     .format(d, strides[d], a.itemsize))
-                arrayInfo.shape_and_index[d] = shape[d]
-                arrayInfo.shape_and_index[d + ndim] = strides[d]
-            arrayInfo.offset = a.data.cl_mem_offset()
-            arrayInfo.size = a.size
+                                     .format(d, a_ndarray._strides[d], a.itemsize))
+                arrayInfo.shape_and_index[d] = a_ndarray._shape[d]
+                arrayInfo.shape_and_index[d + ndim] = a_ndarray._strides[d]
+            arrayInfo.offset = a_ndarray.data.cl_mem_offset()
+            arrayInfo.size = a_ndarray.size
 
             clpy.backend.opencl.api.SetKernelArg(
                 kernel, i, cython.sizeof(Py_ssize_t)*(1+1+2*ndim),

--- a/clpy/backend/function.pyx
+++ b/clpy/backend/function.pyx
@@ -85,7 +85,8 @@ cdef void _launch(clpy.backend.opencl.types.cl_kernel kernel, global_work_size,
                 if a_ndarray._strides[d] % a_ndarray.itemsize != 0:
                     raise ValueError("Stride of dim {0} = {1},"
                                      " but item size is {2}"
-                                     .format(d, a_ndarray._strides[d], a_ndarray.itemsize))
+                                     .format(d, a_ndarray._strides[d],
+                                             a_ndarray.itemsize))
                 arrayInfo.shape_and_index[d] = a_ndarray._shape[d]
                 arrayInfo.shape_and_index[d + ndim] = a_ndarray._strides[d]
             arrayInfo.offset = a_ndarray.data.cl_mem_offset()

--- a/clpy/backend/function.pyx
+++ b/clpy/backend/function.pyx
@@ -82,10 +82,10 @@ cdef void _launch(clpy.backend.opencl.types.cl_kernel kernel, global_work_size,
 
             ndim = a_ndarray._strides.size()
             for d in range(ndim):
-                if a_ndarray._strides[d] % a.itemsize != 0:
+                if a_ndarray._strides[d] % a_ndarray.itemsize != 0:
                     raise ValueError("Stride of dim {0} = {1},"
                                      " but item size is {2}"
-                                     .format(d, a_ndarray._strides[d], a.itemsize))
+                                     .format(d, a_ndarray._strides[d], a_ndarray.itemsize))
                 arrayInfo.shape_and_index[d] = a_ndarray._shape[d]
                 arrayInfo.shape_and_index[d + ndim] = a_ndarray._strides[d]
             arrayInfo.offset = a_ndarray.data.cl_mem_offset()

--- a/clpy/backend/function.pyx
+++ b/clpy/backend/function.pyx
@@ -73,6 +73,12 @@ cdef void _launch(clpy.backend.opencl.types.cl_kernel kernel, global_work_size,
 
     for a in args:
         if isinstance(a, core.ndarray):
+            # Note(y1r):
+            # We give a type hint to Cython to optimize property access.
+            # Without a type hint, Cython deal `a` as Python Object so
+            # dynamic property access (__Pyx_PyObject_GetAttrStr) is required.
+            # By giving type hint, Cython can use static property access for
+            # `cdef` property. More detail, refer to PR#285.
             a_ndarray = <core.ndarray>a
 
             buffer_object = a_ndarray.data.buf.get()


### PR DESCRIPTION
As #280 reported, ClPy is slower than CuPy.
I've optimized the code block 2 by using type declaration.
As a side note, I think we can apply the same technique to code block 2 (in below definition).

# Profile Result
I *redefine* code block as following:
block1: https://github.com/fixstars/clpy/blob/113daf35e92af558e032fb8daa35382d3eafff2c/clpy/backend/function.pyx#L72-L87
block2:
https://github.com/fixstars/clpy/blob/113daf35e92af558e032fb8daa35382d3eafff2c/clpy/backend/function.pyx#L96-L100
block3:
https://github.com/fixstars/clpy/blob/113daf35e92af558e032fb8daa35382d3eafff2c/clpy/backend/function.pyx#L102-L135
block4:
https://github.com/fixstars/clpy/blob/113daf35e92af558e032fb8daa35382d3eafff2c/clpy/backend/function.pyx#L139-L150

PR
```
1    0.008087
2    0.003536
3    0.003453
4    0.000718
```

ClPy
```
1    0.023127
2    0.003196
3    0.003349
4    0.000701
```

# MNIST Result
I show MNIST training time on our `titanv` computer as following:
PR
```
epoch       main/loss   validation/main/loss  main/accuracy  validation/main/accuracy  elapsed_time
1           0.189849    0.128498              0.942917       0.9612                    4.26092
2           0.0736939   0.0813564             0.97725        0.9745                    6.4599
3           0.0484751   0.0705256             0.984332       0.978                     8.62867
4           0.0364001   0.0595562             0.988548       0.9817                    10.8012
5           0.0257702   0.0682672             0.991682       0.9815                    12.9687
6           0.0246192   0.0676164             0.991616       0.9813                    15.1362
7           0.0199016   0.069864              0.993248       0.9822                    17.3253
8           0.0179061   0.0641039             0.994016       0.9839                    19.4983
9           0.0185286   0.067471              0.994216       0.9823                    21.6751
10          0.0159418   0.0818527             0.994965       0.9811                    23.852
11          0.0130928   0.0687815             0.995732       0.9853                    26.026
12          0.0117434   0.0918049             0.996232       0.9814                    28.2031
13          0.0160695   0.0903122             0.994849       0.9832                    30.3753
14          0.0109061   0.074008              0.996532       0.9841                    32.5637
15          0.0103368   0.0850731             0.996565       0.9842                    34.7536
16          0.010364    0.0848928             0.996999       0.9836                    36.9363
17          0.00602149  0.0947524             0.998416       0.9833                    39.1087
18          0.0100751   0.134455              0.997165       0.9784                    41.2822
19          0.0106475   0.0876031             0.996849       0.9842                    43.4577
20          0.0061116   0.104395              0.998299       0.9819                    45.6308
```

ClPy (113daf35e92af558e032fb8daa35382d3eafff2c)
```
epoch       main/loss   validation/main/loss  main/accuracy  validation/main/accuracy  elapsed_time
1           0.18912     0.0936425             0.9431         0.9693                    4.38717
2           0.0752239   0.0780579             0.976483       0.9763                    6.78602
3           0.0481185   0.0758125             0.984482       0.9765                    9.19298
4           0.0336014   0.084627              0.988632       0.9765                    11.5912
5           0.0295318   0.0779823             0.990632       0.98                      14.0011
6           0.0215968   0.0727239             0.992865       0.9804                    16.4161
7           0.0219694   0.0745895             0.992732       0.9804                    18.8121
8           0.0190319   0.0876799             0.993949       0.9778                    21.2214
9           0.0147716   0.0805358             0.995149       0.9805                    23.6251
10          0.0157854   0.0984678             0.994782       0.9786                    26.0361
11          0.0124371   0.078046              0.996149       0.9828                    28.437
12          0.0138706   0.096336              0.995182       0.9787                    30.8825
13          0.010017    0.0971444             0.996982       0.9792                    33.2883
14          0.0105783   0.111755              0.996698       0.9796                    35.6912
15          0.0114829   0.0917043             0.996599       0.9819                    38.0917
16          0.0112482   0.0945839             0.996782       0.9813                    40.4914
17          0.00619665  0.111655              0.998033       0.9801                    42.8943
18          0.0148149   0.0973469             0.995799       0.9821                    45.2913
19          0.00844568  0.0906852             0.997716       0.9817                    47.6912
20          0.00618506  0.106846              0.998049       0.9822                    50.1112
```

CuPy
```
epoch       main/loss   validation/main/loss  main/accuracy  validation/main/accuracy  elapsed_time
1           0.191544    0.0902466             0.942483       0.9713                    2.28341
2           0.0742779   0.0946265             0.97615        0.97                      4.29657
3           0.0478033   0.0725072             0.984732       0.9781                    6.32304
4           0.0364184   0.0691668             0.988415       0.978                     8.38746
5           0.0279623   0.0702349             0.990815       0.9784                    10.4363
6           0.024912    0.0671384             0.991498       0.9815                    12.4576
7           0.0183819   0.0821459             0.993798       0.9789                    14.4749
8           0.0178448   0.0730104             0.994349       0.9815                    16.4942
9           0.0170771   0.0839884             0.994665       0.9786                    18.5136
10          0.0171794   0.0751008             0.994882       0.9837                    20.544
11          0.0111229   0.0723742             0.996599       0.9847                    22.5572
12          0.0122673   0.0790888             0.996132       0.9826                    24.5722
13          0.0144823   0.0881927             0.995266       0.982                     26.5893
14          0.00921393  0.0762939             0.997265       0.9841                    28.6161
15          0.0129496   0.0876335             0.996282       0.9824                    30.6397
16          0.00873685  0.102796              0.997299       0.9831                    32.6593
17          0.0109595   0.102655              0.997048       0.9781                    34.6726
18          0.00886057  0.113294              0.997166       0.9816                    36.6982
19          0.00874232  0.0921475             0.997383       0.9844                    38.7107
20          0.00880212  0.115011              0.997415       0.9809                    40.7427
```